### PR TITLE
fix: Restricciones y vista de chat arregladas

### DIFF
--- a/lib/views/event/event_chat_view.dart
+++ b/lib/views/event/event_chat_view.dart
@@ -52,6 +52,7 @@ class _ChatScreenState extends State<ChatScreen> {
             child: ListView.builder(
               itemCount: messages.length,
               itemBuilder: (BuildContext context, int index) {
+                messages.sort((a, b) => a.date.compareTo(b.date));
                 final message = messages[index];
                 final bool isMe = message.userId == activeUserId;
                 return Container(
@@ -130,7 +131,7 @@ class _ChatScreenState extends State<ChatScreen> {
                             userId: activeUserId,
                             date: DateTime.now(),
                             text: messageToSend.text);
-                        if (m.text != "") {
+                        if (m.text.isNotEmpty) {
                           messagesService.saveMessage(m, selectedEvent);
                           Navigator.popAndPushNamed(context, "chat",
                               arguments: selectedEvent);

--- a/lib/views/event/event_chat_view.dart
+++ b/lib/views/event/event_chat_view.dart
@@ -53,15 +53,30 @@ class _ChatScreenState extends State<ChatScreen> {
               itemCount: messages.length,
               itemBuilder: (BuildContext context, int index) {
                 final message = messages[index];
+                final bool isMe = message.userId == activeUserId;
                 return Container(
-                  margin:
-                      const EdgeInsets.all(8.0), // Margen exterior de la caja
-                  padding:
-                      const EdgeInsets.all(16.0), // Margen interior de la caja
+                  margin: EdgeInsets.only(
+                    top: 8.0,
+                    bottom: 8.0,
+                    left: isMe ? 50.0 : 0.0,
+                    right: isMe ? 0.0 : 50.0,
+                  ),
+                  padding: const EdgeInsets.all(8.0),
                   decoration: BoxDecoration(
-                    color: Colors.blueGrey, // Color de fondo de la caja
-                    borderRadius: BorderRadius.circular(
-                        8.0), // Bordes redondeados de la caja
+                    color: isMe
+                        ? Color.fromARGB(255, 46, 84, 252)
+                        : Color.fromARGB(255, 104, 102, 102),
+                    borderRadius: isMe
+                        ? const BorderRadius.only(
+                            topLeft: Radius.circular(15.0),
+                            bottomLeft: Radius.circular(15.0),
+                            topRight: Radius.circular(15.0),
+                          )
+                        : const BorderRadius.only(
+                            topRight: Radius.circular(15.0),
+                            bottomRight: Radius.circular(15.0),
+                            topLeft: Radius.circular(15.0),
+                          ),
                   ),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -89,26 +104,45 @@ class _ChatScreenState extends State<ChatScreen> {
               },
             ),
           ),
-          CustomTextForm(
-            hintText: 'Escribe tu mensaje aquí...',
-            maxLines: 5,
-            type: TextInputType.multiline,
-            controller: messageToSend,
-            validator: (value) => Validators.validateNotEmpty(value),
+          Container(
+            padding: EdgeInsets.symmetric(horizontal: 8.0),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(10.0),
+              child: Container(
+                color: Colors.lightBlue,
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: CustomTextForm(
+                        hintText: 'Escribe tu mensaje aquí...',
+                        //maxLines: 5,
+                        type: TextInputType.multiline,
+                        controller: messageToSend,
+                        validator: (value) =>
+                            Validators.validateNotEmpty(value),
+                      ),
+                    ),
+                    IconButton(
+                      color: Colors.white,
+                      icon: Icon(Icons.send),
+                      onPressed: () {
+                        Messages m = Messages(
+                            userId: activeUserId,
+                            date: DateTime.now(),
+                            text: messageToSend.text);
+                        if (m.text != "") {
+                          messagesService.saveMessage(m, selectedEvent);
+                          Navigator.popAndPushNamed(context, "chat",
+                              arguments: selectedEvent);
+                        }
+                        messageToSend.clear();
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ),
           ),
-          ElevatedButton(
-              onPressed: () {
-                Messages m = Messages(
-                    userId: activeUserId,
-                    date: DateTime.now(),
-                    text: messageToSend.text);
-                if (m.text != "") {
-                  messagesService.saveMessage(m, selectedEvent);
-                  Navigator.popAndPushNamed(context, "chat",
-                      arguments: selectedEvent);
-                }
-              },
-              child: const Icon(Icons.send)),
         ],
       ),
     );

--- a/lib/views/event/event_chat_view.dart
+++ b/lib/views/event/event_chat_view.dart
@@ -1,8 +1,10 @@
 import 'package:findmyfun/helpers/validators.dart';
 import 'package:findmyfun/models/event.dart';
 import 'package:findmyfun/models/messages.dart';
+import 'package:findmyfun/models/user.dart';
 import 'package:findmyfun/services/auth_service.dart';
 import 'package:findmyfun/services/messages_service.dart';
+import 'package:findmyfun/services/services.dart';
 import 'package:findmyfun/widgets/custom_text_form.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -29,6 +31,7 @@ class _ChatScreenState extends State<ChatScreen> {
     final selectedEvent = ModalRoute.of(context)!.settings.arguments as Event;
     messages = selectedEvent.messages;
     final messagesService = Provider.of<MessagesService>(context);
+    final userService = Provider.of<UsersService>(context, listen: false);
     String activeUserId = AuthService().currentUser?.uid ?? "";
     final messageToSend = TextEditingController();
 
@@ -41,7 +44,6 @@ class _ChatScreenState extends State<ChatScreen> {
               size: 45,
               color: ProjectColors.secondary,
             )),
-        
         title: const Text('Chat'),
       ),
       body: Column(
@@ -51,14 +53,44 @@ class _ChatScreenState extends State<ChatScreen> {
               itemCount: messages.length,
               itemBuilder: (BuildContext context, int index) {
                 final message = messages[index];
-                return ListTile(
-                  title: Text(message.text),
+                return Container(
+                  margin:
+                      const EdgeInsets.all(8.0), // Margen exterior de la caja
+                  padding:
+                      const EdgeInsets.all(16.0), // Margen interior de la caja
+                  decoration: BoxDecoration(
+                    color: Colors.blueGrey, // Color de fondo de la caja
+                    borderRadius: BorderRadius.circular(
+                        8.0), // Bordes redondeados de la caja
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        message.userId,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 12.0,
+                        ),
+                      ),
+                      const SizedBox(
+                          height:
+                              8.0), // Agrega un espacio vertical de 8.0 píxeles
+                      Text(
+                        message.text,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 20.0,
+                        ),
+                      ),
+                    ],
+                  ),
                 );
               },
             ),
           ),
           CustomTextForm(
-            hintText: 'Descripción',
+            hintText: 'Escribe tu mensaje aquí...',
             maxLines: 5,
             type: TextInputType.multiline,
             controller: messageToSend,
@@ -70,9 +102,11 @@ class _ChatScreenState extends State<ChatScreen> {
                     userId: activeUserId,
                     date: DateTime.now(),
                     text: messageToSend.text);
-                messagesService.saveMessage(m, selectedEvent);
-                Navigator.popAndPushNamed(context, "middle",
-                    arguments: selectedEvent);
+                if (m.text != "") {
+                  messagesService.saveMessage(m, selectedEvent);
+                  Navigator.popAndPushNamed(context, "chat",
+                      arguments: selectedEvent);
+                }
               },
               child: const Icon(Icons.send)),
         ],

--- a/lib/views/event/event_details.dart
+++ b/lib/views/event/event_details.dart
@@ -69,13 +69,11 @@ class _FormsColumn extends StatelessWidget {
 
     //List<String> asistentesList = [];
     Future<List<String>> asistentes = Future.delayed(Duration.zero, () async {
-              List<String> users = await eventService.getUsersFromEvent(selectedEvent);
-              List<String> names = await eventService.getNameFromId(users);
-              return names;
-              //asistentesList = names;
-            
-          });
-
+      List<String> users = await eventService.getUsersFromEvent(selectedEvent);
+      List<String> names = await eventService.getNameFromId(users);
+      return names;
+      //asistentesList = names;
+    });
 
     //print(asistentes);
     String activeUserId = AuthService().currentUser?.uid ?? "";
@@ -129,37 +127,37 @@ class _FormsColumn extends StatelessWidget {
                             settings: RouteSettings(arguments: selectedEvent)))
                   },
                 ),
-              ElevatedButton(
-                child: const Text('Abrir chat'),
-                onPressed: () {
-                  Navigator.pushNamed(context, 'chat',
-                      arguments: selectedEvent);
-                },
-              ),
-              FutureBuilder<List<String>>(
-                  future: asistentes,
-                  builder: (context, snapshot) {
-                    if (snapshot.hasData) {
-                      final asistentesList = snapshot.data!;
-                      return ListView.builder(
-                        shrinkWrap: true,
-                        physics: const NeverScrollableScrollPhysics(),
-                        itemCount: asistentesList.length,
-                        itemBuilder: (BuildContext context, int index) {
-                          return ListTile(
-                            leading: const Icon(Icons.person),
-                            title: Text(asistentesList[index]),
-                          );
-                        },
-                      );
-                    } else if (snapshot.hasError) {
-                      return Text('${snapshot.error}');
-                    } else {
-                      return const CircularProgressIndicator();
-                    }
+              if (selectedEvent.users.contains(activeUserId))
+                ElevatedButton(
+                  child: const Text('Abrir chat'),
+                  onPressed: () {
+                    Navigator.pushNamed(context, 'chat',
+                        arguments: selectedEvent);
                   },
                 ),
-                
+              FutureBuilder<List<String>>(
+                future: asistentes,
+                builder: (context, snapshot) {
+                  if (snapshot.hasData) {
+                    final asistentesList = snapshot.data!;
+                    return ListView.builder(
+                      shrinkWrap: true,
+                      physics: const NeverScrollableScrollPhysics(),
+                      itemCount: asistentesList.length,
+                      itemBuilder: (BuildContext context, int index) {
+                        return ListTile(
+                          leading: const Icon(Icons.person),
+                          title: Text(asistentesList[index]),
+                        );
+                      },
+                    );
+                  } else if (snapshot.hasError) {
+                    return Text('${snapshot.error}');
+                  } else {
+                    return const CircularProgressIndicator();
+                  }
+                },
+              ),
             ],
           );
         } else {


### PR DESCRIPTION
Se debe implementar que solo los asistentes del evento puedan acceder al chat y escribir en él.

No te debe permitir mandar mensajes en blanco (o al menos que no se guarden como un mensaje más del chat).

No te debería de dirigir a la pantalla de inicio después de enviar un mensaje.

Mejorar la estética general del chat, pues el fondo blanco no permite distinguir dónde empieza y acaba el campo para enviar un mensaje por ejemplo.