### PR TITLE
Implementación de mapa en los formularios de creación de evento y punto de evento

### DIFF
--- a/lib/screens/event_point_creation_screen.dart
+++ b/lib/screens/event_point_creation_screen.dart
@@ -14,7 +14,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 import '../services/services.dart';
 
-List<Marker> tappedMarker = [];
+List<Marker> tappedMarkerEventPoint = [];
 
 class EventPointCreationScreen extends StatefulWidget {
   const EventPointCreationScreen({Key? key}) : super(key: key);
@@ -120,7 +120,7 @@ class _EventPointCreationScreenState extends State<EventPointCreationScreen> {
                       constraints: BoxConstraints(
                           maxHeight: size.height * 0.5,
                           maxWidth: size.width * 0.8),
-                      child: const MapPlaceSelectorScreen(),
+                      child: const MapPlaceSelectorEventPointScreen(),
                     ),
                     Divider(
                       thickness: 7,
@@ -168,7 +168,8 @@ class _EventPointCreationScreenState extends State<EventPointCreationScreen> {
                                   return;
                                 }
 
-                                Marker selectedMarker = tappedMarker[0];
+                                Marker selectedMarker =
+                                    tappedMarkerEventPoint[0];
 
                                 List<Placemark> selectedPlaceMark =
                                     await placemarkFromCoordinates(
@@ -215,14 +216,16 @@ class _EventPointCreationScreenState extends State<EventPointCreationScreen> {
   }
 }
 
-class MapPlaceSelectorScreen extends StatefulWidget {
-  const MapPlaceSelectorScreen({super.key});
+class MapPlaceSelectorEventPointScreen extends StatefulWidget {
+  const MapPlaceSelectorEventPointScreen({super.key});
 
   @override
-  State<MapPlaceSelectorScreen> createState() => _MapPlaceSelectorScreen();
+  State<MapPlaceSelectorEventPointScreen> createState() =>
+      _MapPlaceSelectorEventPointScreen();
 }
 
-class _MapPlaceSelectorScreen extends State<MapPlaceSelectorScreen> {
+class _MapPlaceSelectorEventPointScreen
+    extends State<MapPlaceSelectorEventPointScreen> {
   late GoogleMapController _googleMapController;
 
   static const _initialCameraPosition = CameraPosition(
@@ -238,7 +241,7 @@ class _MapPlaceSelectorScreen extends State<MapPlaceSelectorScreen> {
         GoogleMap(
           initialCameraPosition: _initialCameraPosition,
           onMapCreated: (controller) => _googleMapController = controller,
-          markers: Set.from(tappedMarker),
+          markers: Set.from(tappedMarkerEventPoint),
           onTap: _handleTapMarker,
           mapType: MapType.normal,
           gestureRecognizers: {
@@ -251,12 +254,10 @@ class _MapPlaceSelectorScreen extends State<MapPlaceSelectorScreen> {
     );
   }
 
-  getLatLongMarker() {}
-
   _handleTapMarker(LatLng tappedPoint) {
     setState(() {
-      tappedMarker.clear();
-      tappedMarker.add(Marker(
+      tappedMarkerEventPoint.clear();
+      tappedMarkerEventPoint.add(Marker(
           markerId: MarkerId(tappedPoint.toString()), position: tappedPoint));
     });
   }

--- a/lib/screens/event_point_creation_screen.dart
+++ b/lib/screens/event_point_creation_screen.dart
@@ -1,17 +1,20 @@
-import 'dart:io';
-
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:findmyfun/helpers/helpers.dart';
 import 'package:findmyfun/models/event_point.dart';
 import 'package:findmyfun/themes/themes.dart';
 import 'package:findmyfun/ui/ui.dart';
 import 'package:findmyfun/widgets/widgets.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:image_picker/image_picker.dart';
+import 'package:geocoding/geocoding.dart';
 import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 import '../services/services.dart';
+
+List<Marker> tappedMarker = [];
 
 class EventPointCreationScreen extends StatefulWidget {
   const EventPointCreationScreen({Key? key}) : super(key: key);
@@ -37,7 +40,7 @@ class _EventPointCreationScreenState extends State<EventPointCreationScreen> {
     decoration: BoxDecoration(
         image: DecorationImage(
             image: Image.asset('assets/placeholder.png').image)),
-    child: Text(
+    child: const Text(
       'Seleccione una imagen de su galería',
       textAlign: TextAlign.center,
     ),
@@ -92,6 +95,7 @@ class _EventPointCreationScreenState extends State<EventPointCreationScreen> {
                         imageUrl = await uploadImage(context,
                             imageId: eventPointId, route: 'EventPoints');
 
+                        // ignore: use_build_context_synchronously
                         Navigator.pop(
                             context); // Cierra el circulo de progreso.
 
@@ -112,34 +116,27 @@ class _EventPointCreationScreenState extends State<EventPointCreationScreen> {
                               ),
                       ),
                     ),
+                    Divider(
+                      thickness: 7,
+                      color: ProjectColors.tertiary,
+                      indent: size.height * 0.05,
+                      endIndent: size.height * 0.05,
+                    ),
+                    ConstrainedBox(
+                      constraints: BoxConstraints(
+                          maxHeight: size.height * 0.5,
+                          maxWidth: size.width * 0.8),
+                      child: const MapPlaceSelectorScreen(),
+                    ),
+                    Divider(
+                      thickness: 7,
+                      color: ProjectColors.tertiary,
+                      indent: size.height * 0.05,
+                      endIndent: size.height * 0.05,
+                    ),
                     CustomTextForm(
                       hintText: 'Nombre',
                       controller: _nameController,
-                      validator: (value) => Validators.validateNotEmpty(value),
-                    ),
-                    CustomTextForm(
-                      hintText: 'Pais',
-                      controller: _countryController,
-                      validator: (value) => Validators.validateNotEmpty(value),
-                    ),
-                    CustomTextForm(
-                      hintText: 'Latitud',
-                      controller: _latitudeController,
-                      validator: (value) => Validators.validateNotEmpty(value),
-                    ),
-                    CustomTextForm(
-                      hintText: 'Longitud',
-                      controller: _longitudeController,
-                      validator: (value) => Validators.validateNotEmpty(value),
-                    ),
-                    CustomTextForm(
-                      hintText: 'Ciudad',
-                      controller: _cityController,
-                      validator: (value) => Validators.validateNotEmpty(value),
-                    ),
-                    CustomTextForm(
-                      hintText: 'Dirección',
-                      controller: _addressController,
                       validator: (value) => Validators.validateNotEmpty(value),
                     ),
                     CustomTextForm(
@@ -167,25 +164,34 @@ class _EventPointCreationScreenState extends State<EventPointCreationScreen> {
                                         MaterialButton(
                                           onPressed: () =>
                                               Navigator.pop(context),
-                                          child: Text('Ok'),
+                                          child: const Text('Ok'),
                                         )
                                       ],
-                                      content: Text(
+                                      content: const Text(
                                           'Por favor, seleccione una imagen'),
                                     ),
                                   );
                                   return;
                                 }
+
+                                Marker selectedMarker = tappedMarker[0];
+
+                                List<Placemark> selectedPlaceMark =
+                                    await placemarkFromCoordinates(
+                                        selectedMarker.position.latitude,
+                                        selectedMarker.position.longitude);
+
+                                Placemark placeMark = selectedPlaceMark[0];
+
                                 final eventPoint = EventPoint(
                                     name: _nameController.text,
                                     description: _descriptionController.text,
                                     longitude:
-                                        double.parse(_longitudeController.text),
-                                    latitude:
-                                        double.parse(_latitudeController.text),
-                                    address: _addressController.text,
-                                    city: _cityController.text,
-                                    country: _countryController.text,
+                                        selectedMarker.position.longitude,
+                                    latitude: selectedMarker.position.latitude,
+                                    address: placeMark.street!,
+                                    city: placeMark.locality!,
+                                    country: placeMark.country!,
                                     image: imageUrl,
                                     id: eventPointId);
                                 showCircularProgressDialog(context);
@@ -212,6 +218,55 @@ class _EventPointCreationScreenState extends State<EventPointCreationScreen> {
             ),
           ),
         ));
+  }
+}
+
+class MapPlaceSelectorScreen extends StatefulWidget {
+  const MapPlaceSelectorScreen({super.key});
+
+  @override
+  State<MapPlaceSelectorScreen> createState() => _MapPlaceSelectorScreen();
+}
+
+class _MapPlaceSelectorScreen extends State<MapPlaceSelectorScreen> {
+  late GoogleMapController _googleMapController;
+
+  static const _initialCameraPosition = CameraPosition(
+    target: LatLng(37.356342, -5.984759),
+    zoom: 13,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          GoogleMap(
+            initialCameraPosition: _initialCameraPosition,
+            onMapCreated: (controller) => _googleMapController = controller,
+            markers: Set.from(tappedMarker),
+            onTap: _handleTapMarker,
+            mapType: MapType.normal,
+            gestureRecognizers: {
+              Factory<OneSequenceGestureRecognizer>(
+                () => EagerGestureRecognizer(),
+              ),
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  getLatLongMarker() {}
+
+  _handleTapMarker(LatLng tappedPoint) {
+    setState(() {
+      tappedMarker.clear();
+      tappedMarker.add(Marker(
+          markerId: MarkerId(tappedPoint.toString()), position: tappedPoint));
+    });
   }
 }
 

--- a/lib/screens/event_point_creation_screen.dart
+++ b/lib/screens/event_point_creation_screen.dart
@@ -26,13 +26,7 @@ class EventPointCreationScreen extends StatefulWidget {
 
 class _EventPointCreationScreenState extends State<EventPointCreationScreen> {
   final _nameController = TextEditingController();
-  final _addressController = TextEditingController();
-  final _latitudeController = TextEditingController();
-  final _longitudeController = TextEditingController();
   final _descriptionController = TextEditingController();
-  final _cityController = TextEditingController();
-  final _countryController = TextEditingController();
-  final _imageController = TextEditingController();
   final _formKey = GlobalKey<FormState>();
 
   Widget placeholder = Container(
@@ -238,24 +232,22 @@ class _MapPlaceSelectorScreen extends State<MapPlaceSelectorScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      child: Stack(
-        alignment: Alignment.center,
-        children: [
-          GoogleMap(
-            initialCameraPosition: _initialCameraPosition,
-            onMapCreated: (controller) => _googleMapController = controller,
-            markers: Set.from(tappedMarker),
-            onTap: _handleTapMarker,
-            mapType: MapType.normal,
-            gestureRecognizers: {
-              Factory<OneSequenceGestureRecognizer>(
-                () => EagerGestureRecognizer(),
-              ),
-            },
-          ),
-        ],
-      ),
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        GoogleMap(
+          initialCameraPosition: _initialCameraPosition,
+          onMapCreated: (controller) => _googleMapController = controller,
+          markers: Set.from(tappedMarker),
+          onTap: _handleTapMarker,
+          mapType: MapType.normal,
+          gestureRecognizers: {
+            Factory<OneSequenceGestureRecognizer>(
+              () => EagerGestureRecognizer(),
+            ),
+          },
+        ),
+      ],
     );
   }
 

--- a/lib/views/event/event_creation_view.dart
+++ b/lib/views/event/event_creation_view.dart
@@ -1,12 +1,19 @@
 import 'package:findmyfun/models/models.dart';
 import 'package:findmyfun/widgets/widgets.dart';
+import 'package:findmyfun/themes/themes.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:geocoding/geocoding.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/foundation.dart';
 
 import '../../helpers/validators.dart';
 import '../../services/services.dart';
 import '../../ui/custom_snackbars.dart';
+
+List<Marker> tappedMarkerEvent = [];
 
 class EventCreationView extends StatelessWidget {
   const EventCreationView({super.key});
@@ -58,6 +65,7 @@ class _FormsColumn extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
     String? id = AuthService().currentUser?.uid ?? "";
     return Form(
       // autovalidateMode: AutovalidateMode.onUserInteraction,
@@ -73,36 +81,28 @@ class _FormsColumn extends StatelessWidget {
             validator: (value) => Validators.validateNotEmpty(value),
           ),
           CustomTextForm(
-            hintText: 'Lugar',
-            controller: _address,
-            validator: (value) => Validators.validateNotEmpty(value),
-          ),
-          CustomTextForm(
-            hintText: 'Ciudad',
-            controller: _city,
-            validator: (value) => Validators.validateNotEmpty(value),
-          ),
-          CustomTextForm(
-            hintText: 'País',
-            controller: _country,
-            validator: (value) => Validators.validateNotEmpty(value),
-          ),
-          CustomTextForm(
-            hintText: 'Latitud',
-            controller: _latitude,
-            validator: (value) => Validators.validateNotEmpty(value),
-          ),
-          CustomTextForm(
-            hintText: 'Longitud',
-            controller: _longitude,
-            validator: (value) => Validators.validateNotEmpty(value),
-          ),
-          CustomTextForm(
             hintText: 'Descripción',
             maxLines: 5,
             type: TextInputType.multiline,
             controller: _description,
             validator: (value) => Validators.validateNotEmpty(value),
+          ),
+          Divider(
+            thickness: 7,
+            color: ProjectColors.tertiary,
+            indent: size.height * 0.05,
+            endIndent: size.height * 0.05,
+          ),
+          ConstrainedBox(
+            constraints: BoxConstraints(
+                maxHeight: size.height * 0.5, maxWidth: size.width * 0.8),
+            child: const MapPlaceSelectorEventScreen(),
+          ),
+          Divider(
+            thickness: 7,
+            color: ProjectColors.tertiary,
+            indent: size.height * 0.05,
+            endIndent: size.height * 0.05,
           ),
           CustomTextForm(
             hintText: 'Link de la imagen',
@@ -144,16 +144,26 @@ class _FormsColumn extends StatelessWidget {
                 );
                 final eventsService =
                     Provider.of<EventsService>(context, listen: false);
+
+                Marker selectedMarker = tappedMarkerEvent[0];
+
+                List<Placemark> selectedPlaceMark =
+                    await placemarkFromCoordinates(
+                        selectedMarker.position.latitude,
+                        selectedMarker.position.longitude);
+
+                Placemark placeMark = selectedPlaceMark[0];
+
                 await eventsService.saveEvent(Event(
-                    address: _address.text,
-                    city: _city.text,
-                    country: _country.text,
+                    address: placeMark.street!,
+                    city: placeMark.locality!,
+                    country: placeMark.country!,
                     description: _description.text,
                     finished: false,
                     image: _image.text,
                     name: _name.text,
-                    latitude: double.parse(_latitude.text),
-                    longitude: double.parse(_longitude.text),
+                    latitude: selectedMarker.position.latitude,
+                    longitude: selectedMarker.position.longitude,
                     startDate: DateTime.parse(
                         '${_startDateTime.text} ${_startTime.text}'),
                     tags: await Future.wait(_selectedValues
@@ -185,5 +195,51 @@ class _FormsColumn extends StatelessWidget {
         ],
       ),
     );
+  }
+}
+
+class MapPlaceSelectorEventScreen extends StatefulWidget {
+  const MapPlaceSelectorEventScreen({super.key});
+
+  @override
+  State<MapPlaceSelectorEventScreen> createState() =>
+      _MapPlaceSelectorEventScreen();
+}
+
+class _MapPlaceSelectorEventScreen extends State<MapPlaceSelectorEventScreen> {
+  late GoogleMapController _googleMapController;
+
+  static const _initialCameraPosition = CameraPosition(
+    target: LatLng(37.356342, -5.984759),
+    zoom: 13,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        GoogleMap(
+          initialCameraPosition: _initialCameraPosition,
+          onMapCreated: (controller) => _googleMapController = controller,
+          markers: Set.from(tappedMarkerEvent),
+          onTap: _handleTapMarker,
+          mapType: MapType.normal,
+          gestureRecognizers: {
+            Factory<OneSequenceGestureRecognizer>(
+              () => EagerGestureRecognizer(),
+            ),
+          },
+        ),
+      ],
+    );
+  }
+
+  _handleTapMarker(LatLng tappedPoint) {
+    setState(() {
+      tappedMarkerEvent.clear();
+      tappedMarkerEvent.add(Marker(
+          markerId: MarkerId(tappedPoint.toString()), position: tappedPoint));
+    });
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   flutter:
     sdk: flutter
   
+  geocoding: ^2.1.0
   google_maps_flutter: ^2.2.5
   http: ^0.13.5
   image_picker: ^0.8.7


### PR DESCRIPTION
Se han realizado cambios para sustituir varios de los campos de ambos formularios por el mapa para que el usuario pueda elegir un punto dentro del mapa.

El diseño y que el se cree el marcador solo al tocar el mapa es provisional, puede ser cambiado si es necesario.