### PR TITLE
Usar la localización actual en el mapa

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.isppg8.findmyfun">
 
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
+
    <application
         android:label="findmyfun"
         android:name="${applicationName}"

--- a/lib/services/map_service.dart
+++ b/lib/services/map_service.dart
@@ -7,11 +7,13 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 class MapService extends ChangeNotifier {
   EventsService eventsService = EventsService();
   EventPointsService eventPointsService = EventPointsService();
+  AuthService authService = AuthService();
 
   // GET ALL MARKERS
   Future<List<Point>> getMarkers() async {
     List<Point> markers = [];
 
+    String currentUser = AuthService().currentUser?.uid ?? "";
     List<Event> events = await eventsService.getEvents();
     List<EventPoint> eventPoints = await eventPointsService.getEventPoints();
 
@@ -21,6 +23,7 @@ class MapService extends ChangeNotifier {
           marker: Marker(
             markerId: MarkerId(event.id),
             position: LatLng(event.latitude, event.longitude),
+            icon: event.users.contains(currentUser) ? BitmapDescriptor.defaultMarkerWithHue(BitmapDescriptor.hueMagenta) : BitmapDescriptor.defaultMarkerWithHue(BitmapDescriptor.hueRed),
           )));
     }
 

--- a/lib/views/event/event_map_view.dart
+++ b/lib/views/event/event_map_view.dart
@@ -121,10 +121,26 @@ class _MapScreenState extends State<MapScreen> {
                       padding: EdgeInsets.symmetric(
                           vertical: size.height * 0.025,
                           horizontal: size.width * 0.01),
-                      height: size.height * 0.1,
-                      width: size.width * 0.6,
+                      height: size.height * 0.13,
+                      width: size.width * 0.7,
                       child: Column(
                         children: [
+                          Row(
+                            children: [
+                              Container(
+                                color: Colors.pink,
+                                height: 10,
+                                width: 10,
+                              ),
+                              const Text(" Eventos a los que estás apuntado",
+                                  style: TextStyle(
+                                    color: Colors.black,
+                                    fontSize: 12,
+                                    decoration: TextDecoration.none,
+                                  )),
+                            ],
+                          ),
+                          SizedBox(height: size.height * 0.01),
                           Row(
                             children: [
                               Container(

--- a/lib/views/event/event_map_view.dart
+++ b/lib/views/event/event_map_view.dart
@@ -60,6 +60,27 @@ class _MapScreenState extends State<MapScreen> {
   }
   
   _getUserCurrentLocation() async {
+    bool serviceEnabled;
+    LocationPermission permission;
+
+    serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) {
+      return Future.error('Location services are disabled');
+    }
+
+    permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+      if (permission == LocationPermission.denied) {
+        return Future.error('Location permissions are denied');
+      }
+    }
+
+    if (permission == LocationPermission.deniedForever) {
+      return Future.error(
+          'Location permissions are permanently denied, we cannot request permissions.');
+    }
+
     Position position = await Geolocator.getCurrentPosition(
         desiredAccuracy: LocationAccuracy.high);
     currentPosition = LatLng(position.latitude, position.longitude);

--- a/lib/views/home/events/event_find_view.dart
+++ b/lib/views/home/events/event_find_view.dart
@@ -2,6 +2,7 @@ import 'package:findmyfun/services/services.dart';
 import 'package:findmyfun/themes/themes.dart';
 import 'package:findmyfun/widgets/widgets.dart';
 import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 class EventFindView extends StatefulWidget {
@@ -115,24 +116,31 @@ class MapScreen extends StatefulWidget {
 }
 
 class _MapScreenState extends State<MapScreen> {
-  static const _initialCameraPosition = CameraPosition(
-    target: LatLng(37.356342, -5.984759),
-    zoom: 13,
-  );
 
   late GoogleMapController _googleMapController;
   late Future markersFuture;
+  // ignore: prefer_const_constructors
+  LatLng currentPosition = LatLng(37.356342, -5.984759);
 
   @override
   void initState() {
     super.initState();
 
     markersFuture = _getMarkers();
+
+    _getUserCurrentLocation();
   }
 
   _getMarkers() async {
     MapService mapService = MapService();
     return await mapService.getMarkers();
+  }
+
+  _getUserCurrentLocation() async {
+    Position position = await Geolocator.getCurrentPosition(
+        desiredAccuracy: LocationAccuracy.high);
+    currentPosition = LatLng(position.latitude, position.longitude);
+    setState(() {});
   }
 
   @override
@@ -155,7 +163,10 @@ class _MapScreenState extends State<MapScreen> {
                 GoogleMap(
                   markers: Set<Marker>.from(
                       snapshot.data!.map((m) => m.marker).toSet()),
-                  initialCameraPosition: _initialCameraPosition,
+                  initialCameraPosition: CameraPosition(
+                                            target: LatLng(currentPosition.latitude, currentPosition.longitude),
+                                            zoom: 15,
+                                          ),
                   onMapCreated: (controller) =>
                       _googleMapController = controller,
                   mapType: MapType.normal,

--- a/lib/views/home/events/event_find_view.dart
+++ b/lib/views/home/events/event_find_view.dart
@@ -138,6 +138,27 @@ class _MapScreenState extends State<MapScreen> {
   }
 
   _getUserCurrentLocation() async {
+    bool serviceEnabled;
+    LocationPermission permission;
+
+    serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) {
+      return Future.error('Location services are disabled');
+    }
+
+    permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+      if (permission == LocationPermission.denied) {
+        return Future.error('Location permissions are denied');
+      }
+    }
+
+    if (permission == LocationPermission.deniedForever) {
+      return Future.error(
+          'Location permissions are permanently denied, we cannot request permissions.');
+    }
+    
     Position position = await Geolocator.getCurrentPosition(
         desiredAccuracy: LocationAccuracy.high);
     currentPosition = LatLng(position.latitude, position.longitude);

--- a/lib/views/register/register_view_form.dart
+++ b/lib/views/register/register_view_form.dart
@@ -132,7 +132,7 @@ class _RegisterFormContainerState extends State<_RegisterFormContainer> {
                     city: _locationController.text,
                     email: _emailController.text,
                     preferences: [
-                      /*models.Preferences(id: '1110', name: 'Futbol')*/
+                      models.Preferences(id: '0001', name: 'Preferencia')
                     ],
                     subscription: models.Subscription(
                         type: models.SubscriptionType.free,

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import firebase_auth
 import firebase_core
 import firebase_storage
+import geolocator_apple
 import path_provider_foundation
 import sqflite
 
@@ -15,6 +16,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
+  GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -277,6 +277,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  geolocator:
+    dependency: "direct main"
+    description:
+      name: geolocator
+      sha256: "5c23f3613f50586c0bbb2b8f970240ae66b3bd992088cf60dd5ee2e6f7dde3a8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.2"
+  geolocator_android:
+    dependency: transitive
+    description:
+      name: geolocator_android
+      sha256: "2ba24690aee0a3e1b6b7bd47c2711a50c874e95e4c758346589d35194adf6d6a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.7"
+  geolocator_apple:
+    dependency: transitive
+    description:
+      name: geolocator_apple
+      sha256: "22b60ca3b8c0f58e6a9688ff855ee39ab813ca3f0c0609a48d282f6631266f2e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.5"
+  geolocator_platform_interface:
+    dependency: transitive
+    description:
+      name: geolocator_platform_interface
+      sha256: af4d69231452f9620718588f41acc4cb58312368716bfff2e92e770b46ce6386
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.7"
+  geolocator_web:
+    dependency: transitive
+    description:
+      name: geolocator_web
+      sha256: f68a122da48fcfff68bbc9846bb0b74ef651afe84a1b1f6ec20939de4d6860e1
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.6"
+  geolocator_windows:
+    dependency: transitive
+    description:
+      name: geolocator_windows
+      sha256: f5911c88e23f48b598dd506c7c19eff0e001645bdc03bb6fecb9f4549208354d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
   google_maps_flutter:
     dependency: "direct main"
     description:
@@ -309,6 +357,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.6"
+  google_mobile_ads:
+    dependency: "direct main"
+    description:
+      name: google_mobile_ads
+      sha256: "01f425afbffbf5e8a8b4bf922709b00d1718ac177597ff215f44c34c99c0f788"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   http:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   
   geocoding: ^2.1.0
   google_maps_flutter: ^2.2.5
+  geolocator: ^9.0.2
   http: ^0.13.5
   image_picker: ^0.8.7
   multiselect: ^0.0.4

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <geolocator_windows/geolocator_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  GeolocatorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("GeolocatorWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  geolocator_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
- Los eventos en los que esté inscrito el usuario logueado se muestran con un color diferente en el mapa de eventos.
- La leyenda del mapa de eventos muestra el nuevo color de los eventos del usuario logueado.
- El mapa se debe centrar en la localización actual del usuario (Probar cambiando la localización en el emulador y dándole al botón de recentrado).
- Comprobar que pide permiso para obtener la localización.
- En el caso de denegar los permisos, se centraría en la ETSII.
- Al registrarse un usuario, se le añade una preferencia fantasma con id '0001' y name 'Preferencia' para evitar que de error al no tener ninguna preferencia.