### PR TITLE
Plan de pago backend

### DIFF
--- a/lib/helpers/validators.dart
+++ b/lib/helpers/validators.dart
@@ -26,13 +26,16 @@ class Validators {
     }
   }
 
-  static String? validateDateRange(String? value, int advanced) {
+  static String? validateDateTimeRange(String? value, int advanced) {
     RegExp regExp =
-        RegExp(r'^\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])$');
+        RegExp(r'^\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01]) ([0-1]?[0-9]|2[0-3]):[0-5][0-9]$');
 
     DateTime? dateTime;
     DateTime now;
+    print("test print 1");
+    print("test print 2: ${value}");
     if (value != null && regExp.hasMatch(value)) {
+      print("test print 3: ${value}");
       dateTime = DateTime.parse(value);
       now = DateTime.now();
       final difference =

--- a/lib/helpers/validators.dart
+++ b/lib/helpers/validators.dart
@@ -37,6 +37,32 @@ class Validators {
     }
   }
 
+  static String? validateDateRange(String? value, int advanced) {
+    RegExp regExp =
+        RegExp(r'^\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])$');
+    
+    DateTime? dateTime;
+    DateTime now;
+    if (value != null && regExp.hasMatch(value)) {
+      dateTime = DateTime.parse(value);
+      now = DateTime.now();
+      final difference = dateTime.millisecondsSinceEpoch - now.millisecondsSinceEpoch;
+      final differenceInDays = Duration(days: (difference / (1000 * 60 * 60 * 24)).floor()).inDays;
+      
+      if (!dateTime.isAfter(now)) {
+        return 'Solo puedes crear eventos con fecha en el futuro.';
+      }
+
+      if (advanced != -1 && differenceInDays > advanced) {
+        return 'Solo puedes crear eventos con $advanced días de antelación.';
+      }
+      
+      return null;
+    } else {
+      return 'Invalid date format';
+    }
+  }
+
   static String? validateTime(String? value) {
     RegExp regExp = RegExp(r'^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$');
 

--- a/lib/helpers/validators.dart
+++ b/lib/helpers/validators.dart
@@ -27,15 +27,12 @@ class Validators {
   }
 
   static String? validateDateTimeRange(String? value, int advanced) {
-    RegExp regExp =
-        RegExp(r'^\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01]) ([0-1]?[0-9]|2[0-3]):[0-5][0-9]$');
+    RegExp regExp = RegExp(
+        r'^\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01]) ([0-1]?[0-9]|2[0-3]):[0-5][0-9]$');
 
     DateTime? dateTime;
     DateTime now;
-    print("test print 1");
-    print("test print 2: ${value}");
     if (value != null && regExp.hasMatch(value)) {
-      print("test print 3: ${value}");
       dateTime = DateTime.parse(value);
       now = DateTime.now();
       final difference =

--- a/lib/models/event.dart
+++ b/lib/models/event.dart
@@ -8,7 +8,6 @@ class Event {
     required this.city,
     required this.country,
     required this.description,
-    required this.finished,
     required this.id,
     required this.image,
     required this.name,
@@ -26,7 +25,6 @@ class Event {
   String city;
   String country;
   String description;
-  bool finished;
   String id;
   String image;
   String name;
@@ -56,7 +54,6 @@ class Event {
       city: json["city"],
       country: json["country"],
       description: json["description"],
-      finished: json["finished"],
       id: json["id"],
       image: json["image"],
       name: json["name"],
@@ -83,7 +80,6 @@ class Event {
         "city": city,
         "country": country,
         "description": description,
-        "finished": finished,
         "id": id,
         "image": image,
         "name": name,
@@ -101,5 +97,5 @@ class Event {
 
   @override
   String toString() =>
-      'address: $address, city: $city, country: $country, description: $description, finished: $finished, id: $id, image: $image, name: $name, latitude: $latitude, longitude: $longitude, startDate: $startDate, visibleFrom: $visibleFrom, tags: $tags, users: $users, maxUsers: $maxUsers, messages: $messages';
+      'address: $address, city: $city, country: $country, description: $description, id: $id, image: $image, name: $name, latitude: $latitude, longitude: $longitude, startDate: $startDate, visibleFrom: $visibleFrom, tags: $tags, users: $users, maxUsers: $maxUsers, messages: $messages';
 }

--- a/lib/models/event.dart
+++ b/lib/models/event.dart
@@ -15,6 +15,7 @@ class Event {
     required this.latitude,
     required this.longitude,
     required this.startDate,
+    required this.visibleFrom,
     required this.tags,
     required this.users,
     required this.maxUsers,
@@ -32,6 +33,7 @@ class Event {
   double latitude;
   double longitude;
   DateTime startDate;
+  DateTime visibleFrom;
   List<Preferences> tags;
   List<String> users;
   int maxUsers;
@@ -42,6 +44,8 @@ class Event {
   String get creator => users.first;
 
   bool get isFull => maxUsers != -1 && users.length >= maxUsers;
+
+  bool get isVisible => visibleFrom.isBefore(DateTime.now());
 
   factory Event.fromRawJson(String str) => Event.fromJson(json.decode(str));
 
@@ -59,6 +63,7 @@ class Event {
       latitude: json["latitude"],
       longitude: json["longitude"],
       startDate: DateTime.parse(json["startDate"]),
+      visibleFrom: json["visibleFrom"] != null ? DateTime.parse(json["visibleFrom"]) : DateTime.fromMillisecondsSinceEpoch(0),
       tags: Map.from(json["tags"])
           .map((k, v) =>
               MapEntry<String, Preferences>(k, Preferences.fromJson(v)))
@@ -85,6 +90,7 @@ class Event {
         "latitude": latitude,
         "longitude": longitude,
         "startDate": startDate.toIso8601String(),
+        "visibleFrom": visibleFrom.toIso8601String(),
         "tags": Map.from(tags.fold({}, (r, p) => r..[p.id] = p))
             .map((k, v) => MapEntry<String, dynamic>(k, v.toJson())),
         "users": List<String>.from(users.map((x) => x)),
@@ -95,5 +101,5 @@ class Event {
 
   @override
   String toString() =>
-      'address: $address, city: $city, country: $country, description: $description, finished: $finished, id: $id, image: $image, name: $name, latitude: $latitude, longitude: $longitude, startDate: $startDate, tags: $tags, users: $users, maxUsers: $maxUsers, messages: $messages';
+      'address: $address, city: $city, country: $country, description: $description, finished: $finished, id: $id, image: $image, name: $name, latitude: $latitude, longitude: $longitude, startDate: $startDate, visibleFrom: $visibleFrom, tags: $tags, users: $users, maxUsers: $maxUsers, messages: $messages';
 }

--- a/lib/models/subscription.dart
+++ b/lib/models/subscription.dart
@@ -18,7 +18,7 @@ class Subscription {
           ? 15
           : -1;
 
-  int get maxTimeInAdvanceToJoinEventsInDays => type == SubscriptionType.free
+  int get maxTimeInAdvanceToCreateEventsInDays => type == SubscriptionType.free
       ? 10
       : type == SubscriptionType.premium
           ? 30

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -17,6 +17,7 @@ class User {
     required this.preferences,
     this.isAdmin = false,
     this.isCompany = false,
+    this.isPremium = false,
     required this.subscription,
   });
 
@@ -30,6 +31,8 @@ class User {
   List<Preferences?> preferences;
   bool? isAdmin;
   bool? isCompany;
+  bool? isPremium;
+
   Subscription subscription;
 
   factory User.fromRawJson(String str) => User.fromJson(json.decode(str));
@@ -53,8 +56,8 @@ class User {
           : [],
       isAdmin: json["isAdmin"] ?? false,
       isCompany: json["isCompany"] ?? false,
-      subscription: Subscription.fromJson(json["subscription"])
-      );
+      subscription: Subscription.fromJson(json["subscription"]),
+      isPremium: json["isPremium"] ?? false);
 
   Map<String, dynamic> toJson() => {
         "id": id,
@@ -69,5 +72,6 @@ class User {
         "isAdmin": isAdmin,
         "isCompany": isCompany,
         "subscription": subscription.toJson(),
+        "isPremium": isPremium
       };
 }

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -16,8 +16,6 @@ class User {
     required this.email,
     required this.preferences,
     this.isAdmin = false,
-    this.isCompany = false,
-    this.isPremium = false,
     required this.subscription,
   });
 
@@ -30,9 +28,6 @@ class User {
   String email;
   List<Preferences?> preferences;
   bool? isAdmin;
-  bool? isCompany;
-  bool? isPremium;
-
   Subscription subscription;
 
   factory User.fromRawJson(String str) => User.fromJson(json.decode(str));
@@ -55,9 +50,8 @@ class User {
               .toList()
           : [],
       isAdmin: json["isAdmin"] ?? false,
-      isCompany: json["isCompany"] ?? false,
-      subscription: Subscription.fromJson(json["subscription"]),
-      isPremium: json["isPremium"] ?? false);
+      subscription: Subscription.fromJson(json["subscription"])
+      );
 
   Map<String, dynamic> toJson() => {
         "id": id,
@@ -70,8 +64,6 @@ class User {
         "preferences": Map.from(preferences.fold({}, (r, p) => r..[p?.id] = p))
             .map((k, v) => MapEntry<String, dynamic>(k, v.toJson())),
         "isAdmin": isAdmin,
-        "isCompany": isCompany,
-        "subscription": subscription.toJson(),
-        "isPremium": isPremium
+        "subscription": subscription.toJson()
       };
 }

--- a/lib/screens/event_point_creation_screen.dart
+++ b/lib/screens/event_point_creation_screen.dart
@@ -2,7 +2,6 @@
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:findmyfun/helpers/helpers.dart';
-import 'package:findmyfun/models/event_point.dart';
 import 'package:findmyfun/services/important_notification_service.dart';
 import 'package:findmyfun/themes/themes.dart';
 import 'package:findmyfun/ui/ui.dart';
@@ -146,7 +145,6 @@ class _EventPointCreationScreenState extends State<EventPointCreationScreen> {
                   mainAxisAlignment: MainAxisAlignment.spaceAround,
                   children: [
                     SizedBox(height: size.height * 0.005),
-                    const CustomAd(),
                     const Divider(
                       color: Colors.grey,
                       thickness: 0.5,
@@ -287,7 +285,6 @@ class _EventPointCreationScreenState extends State<EventPointCreationScreen> {
                                     country: placeMark.country!,
                                     image: imageUrl,
                                     id: eventPointId);
-                                // ignore: use_build_context_synchronously
                                 showCircularProgressDialog(context);
                                 await eventPointsService.saveEventPoint(
                                     eventPoint, usersService.currentUser!);

--- a/lib/screens/event_point_creation_screen.dart
+++ b/lib/screens/event_point_creation_screen.dart
@@ -144,7 +144,6 @@ class _EventPointCreationScreenState extends State<EventPointCreationScreen> {
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.spaceAround,
                   children: [
-                    SizedBox(height: size.height * 0.005),
                     const Divider(
                       color: Colors.grey,
                       thickness: 0.5,

--- a/lib/services/ad_service.dart
+++ b/lib/services/ad_service.dart
@@ -4,16 +4,16 @@ import 'package:flutter/material.dart';
 class AdService extends ChangeNotifier {
   static String? get bannerAdUnitId {
     if (Platform.isAndroid) {
-      //return 'ca-app-pub-8269759683506975/4500501066'; //Id de producción
-      return 'ca-app-pub-3940256099942544/6300978111'; // Id de testeo
+      return 'ca-app-pub-8269759683506975/4500501066'; //Id de producción
+      //return 'ca-app-pub-3940256099942544/6300978111'; // Id de testeo
     }
     return null;
   }
 
   static String? get interstitialAdUnitId {
     if (Platform.isAndroid) {
-      //return 'ca-app-pub-8269759683506975/4500501066'; //Id de producción
-      return 'ca-app-pub-3940256099942544/1033173712'; // Id de testeo
+      return 'ca-app-pub-8269759683506975/4500501066'; //Id de producción
+      //return 'ca-app-pub-3940256099942544/1033173712'; // Id de testeo
     }
     return null;
   }

--- a/lib/services/event_points_service.dart
+++ b/lib/services/event_points_service.dart
@@ -20,7 +20,7 @@ class EventPointsService extends ChangeNotifier {
 
   //POST AND UPDATE EVENT POINT
   Future<void> saveEventPoint(EventPoint eventPoint, User currentUser) async {
-    if (currentUser.isCompany == null || currentUser.isCompany == false) return;
+    if (currentUser.subscription.type != SubscriptionType.company) return;
     final url = Uri.https(_baseUrl, 'EventPoints/${eventPoint.id}.json');
     try {
       final resp = await http.put(url, body: jsonEncode(eventPoint.toJson()));

--- a/lib/services/event_points_service.dart
+++ b/lib/services/event_points_service.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:findmyfun/services/important_notification_service.dart';
 import 'package:http/http.dart' as http;
 
 import '../models/models.dart';

--- a/lib/services/events_service.dart
+++ b/lib/services/events_service.dart
@@ -1,12 +1,11 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:findmyfun/models/models.dart';
 import 'package:findmyfun/services/auth_service.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
-import '../models/event.dart';
-import '../models/user.dart';
 import 'users_service.dart';
 
 class EventsService extends ChangeNotifier {
@@ -30,8 +29,8 @@ class EventsService extends ChangeNotifier {
   Future<void> deleteEvent(String eventId) async {
     final url = Uri.https(_baseUrl, 'Events/$eventId.json');
     try {
+      // ignore: unused_local_variable
       final resp = await http.delete(url);
-      debugPrint(resp.body);
     } catch (e) {
       debugPrint('Error al eliminar el evento: $e');
     }
@@ -155,10 +154,10 @@ class EventsService extends ChangeNotifier {
     String eventId = event.id;
     String activeUserId = AuthService().currentUser?.uid ?? "";
     final usersService = Provider.of<UsersService>(context, listen: false);
-    if (usersService.currentUser!.isCompany == true) return;
+    if (usersService.currentUser!.subscription.type == SubscriptionType.company) return;
     if (activeUserId.isEmpty ||
         eventId.isEmpty ||
-        event.finished == true ||
+        event.hasFinished == true ||
         event.users.contains(activeUserId)) {
       throw Exception(
           'Asegúrate de haber iniciado sesión, de que el evento existe y está activo no estás dentro de él');
@@ -312,14 +311,10 @@ class EventsService extends ChangeNotifier {
   Future<List<String>> getNameFromId(List<String> ids) async {
     try {
       List<String> usersAux = [];
-      // ignore: avoid_print
-      print(ids);
       for (var id in ids) {
         final resp = await http.get(Uri.https(_baseUrl, 'Users/$id.json'));
 
         Map<String, dynamic> data = jsonDecode(resp.body);
-        // ignore: avoid_print
-        print(data["username"]);
         usersAux.add(data["username"]);
       }
       // ignore: avoid_print

--- a/lib/services/events_service.dart
+++ b/lib/services/events_service.dart
@@ -154,6 +154,9 @@ class EventsService extends ChangeNotifier {
       throw Exception(
           'Asegúrate de haber iniciado sesión, de que el evento existe y está activo no estás dentro de él');
     } else {
+      if (event.isFull) {
+        throw Exception('Error: Event is full');
+      }
       event.users.add(activeUserId);
       final url = Uri.https(_baseUrl, 'Events/$eventId.json');
 

--- a/lib/services/events_service.dart
+++ b/lib/services/events_service.dart
@@ -75,6 +75,38 @@ class EventsService extends ChangeNotifier {
     }
   }
 
+  //GET EVENT OF LOGGED USER
+  Future<List<Event>> getEventsOfLoggedUser() async {
+    final url = Uri.https(_baseUrl, 'Events.json');
+    final currentUser = AuthService().currentUser?.uid ?? "";
+
+    try {
+      final resp = await http.get(url);
+
+      if (resp.statusCode != 200) {
+        throw Exception('Error in response');
+      }
+      List<Event> eventsAux = [];
+      Map<String, dynamic> data = jsonDecode(resp.body);
+
+      data.forEach((key, value) {
+        try {
+          final event = Event.fromRawJson(jsonEncode(value));
+          if (event.users.contains(currentUser)) {
+            eventsAux.add(event);
+          }
+        } catch (e) {
+          debugPrint('Error parsing event: $e');
+        }
+      });
+
+      events = eventsAux;
+      return eventsAux;
+    } catch (e) {
+      throw Exception('Error getting events: $e');
+    }
+  }
+
   //FIND EVENTS
   Future<List<Event>> findEvents() async {
     final url = Uri.https(_baseUrl, 'Events.json');

--- a/lib/services/events_service.dart
+++ b/lib/services/events_service.dart
@@ -154,7 +154,8 @@ class EventsService extends ChangeNotifier {
     String eventId = event.id;
     String activeUserId = AuthService().currentUser?.uid ?? "";
     final usersService = Provider.of<UsersService>(context, listen: false);
-    if (usersService.currentUser!.subscription.type == SubscriptionType.company) return;
+    if (usersService.currentUser!.subscription.type == SubscriptionType.company)
+      return;
     final notificationsService =
         Provider.of<ImportantNotificationService>(context, listen: false);
     if (activeUserId.isEmpty ||
@@ -178,9 +179,9 @@ class EventsService extends ChangeNotifier {
           date: DateTime.now(),
           info: "${currentUser!.name} se ha unido al evento ${event.name}");
       notificationsService.saveNotification(
-          context, notificationUsuarioEntra, activeUserId);
-      notificationsService.saveNotification(
           context, notificationDuenoEvento, event.creator);
+      notificationsService.saveNotification(
+          context, notificationUsuarioEntra, activeUserId);
       final url = Uri.https(_baseUrl, 'Events/$eventId.json');
 
       try {

--- a/lib/services/events_service.dart
+++ b/lib/services/events_service.dart
@@ -107,7 +107,7 @@ class EventsService extends ChangeNotifier {
     }
   }
 
-  //FIND EVENTS
+  //FIND EVENTS THAT SHARE TAGS WITH USER, ARE NOT FULL, ARE VISIBLE, ARE NOT FINISHED AND USER IS NOT IN
   Future<List<Event>> findEvents() async {
     final url = Uri.https(_baseUrl, 'Events.json');
     final UsersService usersService = UsersService();
@@ -130,7 +130,10 @@ class EventsService extends ChangeNotifier {
                   .toSet()
                   .intersection(event.tags.toSet())
                   .isNotEmpty &&
-              !event.hasFinished /* && currentUser.city == event.city*/) {
+              !event.hasFinished &&
+              event.isVisible &&
+              !event.isFull &&
+              !event.users.contains(currentUser.id)) {
             eventsAux.add(event);
           }
         } catch (e) {

--- a/lib/services/events_service.dart
+++ b/lib/services/events_service.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:findmyfun/services/auth_service.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+import 'package:provider/provider.dart';
 import '../models/event.dart';
 import '../models/user.dart';
 import 'users_service.dart';
@@ -37,8 +38,11 @@ class EventsService extends ChangeNotifier {
   }
 
   //POST AND UPDATE EVENT
-  Future<void> saveEvent(Event event) async {
+  Future<void> saveEvent(BuildContext context, Event event) async {
+    final usersService = Provider.of<UsersService>(context, listen: false);
+    if (!usersService.currentUser!.subscription.canCreateEvents) return;
     final url = Uri.https(_baseUrl, 'Events/${event.id}.json');
+
     try {
       // ignore: unused_local_variable
       final resp = await http.put(url, body: jsonEncode(event.toJson()));
@@ -147,9 +151,11 @@ class EventsService extends ChangeNotifier {
     }
   }
 
-  Future<void> addUserToEvent(Event event) async {
+  Future<void> addUserToEvent(BuildContext context, Event event) async {
     String eventId = event.id;
     String activeUserId = AuthService().currentUser?.uid ?? "";
+    final usersService = Provider.of<UsersService>(context, listen: false);
+    if (usersService.currentUser!.isCompany == true) return;
     if (activeUserId.isEmpty ||
         eventId.isEmpty ||
         event.finished == true ||

--- a/lib/services/important_notification_service.dart
+++ b/lib/services/important_notification_service.dart
@@ -22,7 +22,7 @@ class ImportantNotificationService extends ChangeNotifier {
 
   //READ NOTIFICATIONS
   Future<void> getNotifications(String userId) async {
-    final url = Uri.https(_baseUrl, 'Users/${userId}.json');
+    final url = Uri.https(_baseUrl, 'Users/$userId.json');
     try {
       final resp = await http.get(url);
 
@@ -61,8 +61,9 @@ class ImportantNotificationService extends ChangeNotifier {
     final usersService = Provider.of<UsersService>(context, listen: false);
     final currentUser = usersService.currentUser;
     currentUser!.notifications.add(notification);
-    final url = Uri.https(_baseUrl, 'Users/${userId}.json');
+    final url = Uri.https(_baseUrl, 'Users/$userId.json');
     try {
+      // ignore: unused_local_variable
       final resp = await http.put(url, body: jsonEncode(currentUser));
     } catch (e) {
       debugPrint('Error posting notification: $e');

--- a/lib/services/important_notification_service.dart
+++ b/lib/services/important_notification_service.dart
@@ -59,8 +59,8 @@ class ImportantNotificationService extends ChangeNotifier {
   Future<void> saveNotification(BuildContext context,
       ImportantNotification notification, String userId) async {
     final usersService = Provider.of<UsersService>(context, listen: false);
-    final currentUser = usersService.currentUser;
-    currentUser!.notifications.add(notification);
+    final currentUser = await usersService.getUserWithUid(userId);
+    currentUser.notifications.add(notification);
     final url = Uri.https(_baseUrl, 'Users/$userId.json');
     try {
       // ignore: unused_local_variable

--- a/lib/services/map_service.dart
+++ b/lib/services/map_service.dart
@@ -18,12 +18,18 @@ class MapService extends ChangeNotifier {
     List<EventPoint> eventPoints = await eventPointsService.getEventPoints();
 
     for (var event in events) {
+      if (event.hasFinished || !event.isVisible) continue;
+      if (event.isFull && !event.users.contains(currentUser)) continue;
       markers.add(Point(
           event: event,
           marker: Marker(
             markerId: MarkerId(event.id),
             position: LatLng(event.latitude, event.longitude),
-            icon: event.users.contains(currentUser) ? BitmapDescriptor.defaultMarkerWithHue(BitmapDescriptor.hueMagenta) : BitmapDescriptor.defaultMarkerWithHue(BitmapDescriptor.hueRed),
+            icon: event.users.contains(currentUser)
+                ? BitmapDescriptor.defaultMarkerWithHue(
+                    BitmapDescriptor.hueMagenta)
+                : BitmapDescriptor.defaultMarkerWithHue(
+                    BitmapDescriptor.hueRed),
           )));
     }
 

--- a/lib/services/services.dart
+++ b/lib/services/services.dart
@@ -5,5 +5,6 @@ export 'package:findmyfun/services/map_service.dart';
 export 'package:findmyfun/services/messages_service.dart';
 export 'package:findmyfun/services/page_view_service.dart';
 export 'package:findmyfun/services/preferences_service.dart';
+export 'package:findmyfun/services/subscription_service.dart';
 export 'package:findmyfun/services/users_service.dart';
 export 'package:findmyfun/services/ad_service.dart';

--- a/lib/services/subscription_service.dart
+++ b/lib/services/subscription_service.dart
@@ -1,0 +1,31 @@
+import 'dart:convert';
+//import 'dart:html';
+
+import 'package:findmyfun/services/services.dart';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:provider/provider.dart';
+
+class SubscriptionService extends ChangeNotifier {
+  final String _baseUrl = 'findmyfun-c0acc-default-rtdb.firebaseio.com';
+  final UsersService usersService = UsersService();
+  final currentAuthUser = AuthService().currentUser;
+
+  //UPDATE PROFILE
+  Future<bool> updateEventCount(BuildContext context, String userId) async {
+    final usersService = Provider.of<UsersService>(context, listen: false);
+    final currentUser = usersService.currentUser;
+    currentUser!.subscription.numEventsCreatedThisMonth += 1;
+    final url = Uri.https(_baseUrl, 'Users/$userId.json');
+    try {
+      // ignore: unused_local_variable
+      final resp = await http.put(url, body: jsonEncode(currentUser));
+
+      if (resp.statusCode != 200) return false;
+      return true;
+    } catch (e) {
+      debugPrint('Error editing profile: $e');
+      return false;
+    }
+  }
+}

--- a/lib/views/event/event_chat_view.dart
+++ b/lib/views/event/event_chat_view.dart
@@ -1,10 +1,7 @@
 import 'package:findmyfun/helpers/validators.dart';
-import 'package:findmyfun/models/event.dart';
-import 'package:findmyfun/models/messages.dart';
 import 'package:findmyfun/models/models.dart';
 import 'package:findmyfun/services/services.dart';
-import 'package:findmyfun/widgets/custom_banner_ad.dart';
-import 'package:findmyfun/widgets/custom_text_form.dart';
+import 'package:findmyfun/widgets/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -50,7 +47,7 @@ class _ChatScreenState extends State<ChatScreen> {
       body: Column(
         children: [
           SizedBox(height: size.height * 0.005),
-          const CustomAd(),
+          const AdPlanLoader(),
           Expanded(
             child: ListView.builder(
               itemCount: messages.length,

--- a/lib/views/event/event_creation_view.dart
+++ b/lib/views/event/event_creation_view.dart
@@ -285,40 +285,42 @@ class _FormsColumnState extends State<_FormsColumn> {
                 Placemark placeMark = selectedPlaceMark[0];
 
                 if (loggedUser.subscription.canCreateEvents) {
-                  await eventsService.saveEvent(Event(
-                      address: placeMark.street!,
-                      city: placeMark.locality!,
-                      country: placeMark.country!,
-                      description: _description.text,
-                      finished: false,
-                      image: _image.text,
-                      name: _name.text,
-                      latitude: selectedMarker.position.latitude,
-                      longitude: selectedMarker.position.longitude,
-                      startDate: DateTime.parse(
-                          '${_startDateTime.text} ${_startTime.text}'),
-                      visibleFrom: loggedUser
-                                  .subscription.maxVisiblityOfEventsInDays ==
-                              -1
-                          ? DateTime.fromMillisecondsSinceEpoch(0)
-                          : DateTime.parse(
-                                  '${_startDateTime.text} ${_startTime.text}')
-                              .subtract(Duration(
-                                  days: loggedUser.subscription
-                                      .maxVisiblityOfEventsInDays)),
-                      tags: await Future.wait(_selectedValues
-                          .map((e) => PreferencesService()
-                              .getPreferenceByName(e.toString()))
-                          .toList()),
-                      users: [id],
-                      maxUsers: loggedUser.subscription.maxUsersPerEvent,
-                      messages: [
-                        Messages(
-                            userId: "8AH3CM76DydLFLrAQANT2gTBYlk2",
-                            date: DateTime.now(),
-                            text: "Bienvenido")
-                      ],
-                      id: const Uuid().v1()));
+                  await eventsService.saveEvent(
+                      context,
+                      Event(
+                          address: placeMark.street!,
+                          city: placeMark.locality!,
+                          country: placeMark.country!,
+                          description: _description.text,
+                          finished: false,
+                          image: _image.text,
+                          name: _name.text,
+                          latitude: selectedMarker.position.latitude,
+                          longitude: selectedMarker.position.longitude,
+                          startDate: DateTime.parse(
+                              '${_startDateTime.text} ${_startTime.text}'),
+                          visibleFrom: loggedUser.subscription
+                                      .maxVisiblityOfEventsInDays ==
+                                  -1
+                              ? DateTime.fromMillisecondsSinceEpoch(0)
+                              : DateTime.parse(
+                                      '${_startDateTime.text} ${_startTime.text}')
+                                  .subtract(Duration(
+                                      days: loggedUser.subscription
+                                          .maxVisiblityOfEventsInDays)),
+                          tags: await Future.wait(_selectedValues
+                              .map((e) => PreferencesService()
+                                  .getPreferenceByName(e.toString()))
+                              .toList()),
+                          users: [id],
+                          maxUsers: loggedUser.subscription.maxUsersPerEvent,
+                          messages: [
+                            Messages(
+                                userId: "8AH3CM76DydLFLrAQANT2gTBYlk2",
+                                date: DateTime.now(),
+                                text: "Bienvenido")
+                          ],
+                          id: const Uuid().v1()));
 
                   loggedUser.subscription.numEventsCreatedThisMonth++;
                   UsersService().updateProfile(loggedUser);

--- a/lib/views/event/event_creation_view.dart
+++ b/lib/views/event/event_creation_view.dart
@@ -77,8 +77,16 @@ class _EventCreationView extends State<EventCreationView> {
                       child: _FormsColumn(),
                     );
                   } else {
-                    return const Center(
-                      child: Text('Ya no puedes crear más eventos este mes'),
+                    return SizedBox(
+                      height: size.height * 0.6,
+                      width: size.width * 0.8,
+                      child: const Center(
+                          child: Text('Ya no puedes crear más eventos este mes',
+                              textAlign: TextAlign.center,
+                              style: TextStyle(
+                                  color: ProjectColors.tertiary,
+                                  fontSize: 20,
+                                  fontWeight: FontWeight.bold))),
                     );
                   }
                 } else {

--- a/lib/views/event/event_creation_view.dart
+++ b/lib/views/event/event_creation_view.dart
@@ -229,7 +229,7 @@ class _FormsColumnState extends State<_FormsColumn> {
           CustomTextForm(
             hintText: 'Fecha: aaaa-MM-dd',
             controller: _startDateTime,
-            validator: (value) => Validators.validateDate(value),
+            validator: (value) => Validators.validateDate(value) ?? Validators.validateDateRange(value, loggedUser.subscription.maxTimeInAdvanceToCreateEventsInDays),
           ),
           const Text(
             "Hora",

--- a/lib/views/event/event_creation_view.dart
+++ b/lib/views/event/event_creation_view.dart
@@ -229,7 +229,12 @@ class _FormsColumnState extends State<_FormsColumn> {
           CustomTextForm(
             hintText: 'Fecha: aaaa-MM-dd',
             controller: _startDateTime,
-            validator: (value) => Validators.validateDate(value) ?? Validators.validateDateRange(value, loggedUser.subscription.maxTimeInAdvanceToCreateEventsInDays),
+            validator: (value) =>
+                Validators.validateDate(value) ??
+                Validators.validateDateRange(
+                    value,
+                    loggedUser
+                        .subscription.maxTimeInAdvanceToCreateEventsInDays),
           ),
           const Text(
             "Hora",
@@ -292,6 +297,15 @@ class _FormsColumnState extends State<_FormsColumn> {
                       longitude: selectedMarker.position.longitude,
                       startDate: DateTime.parse(
                           '${_startDateTime.text} ${_startTime.text}'),
+                      visibleFrom: loggedUser
+                                  .subscription.maxVisiblityOfEventsInDays ==
+                              -1
+                          ? DateTime.fromMillisecondsSinceEpoch(0)
+                          : DateTime.parse(
+                                  '${_startDateTime.text} ${_startTime.text}')
+                              .subtract(Duration(
+                                  days: loggedUser.subscription
+                                      .maxVisiblityOfEventsInDays)),
                       tags: await Future.wait(_selectedValues
                           .map((e) => PreferencesService()
                               .getPreferenceByName(e.toString()))

--- a/lib/views/event/event_creation_view.dart
+++ b/lib/views/event/event_creation_view.dart
@@ -285,6 +285,7 @@ class _FormsColumnState extends State<_FormsColumn> {
                 Placemark placeMark = selectedPlaceMark[0];
 
                 if (loggedUser.subscription.canCreateEvents) {
+                  // ignore: use_build_context_synchronously
                   await eventsService.saveEvent(
                       context,
                       Event(
@@ -292,7 +293,6 @@ class _FormsColumnState extends State<_FormsColumn> {
                           city: placeMark.locality!,
                           country: placeMark.country!,
                           description: _description.text,
-                          finished: false,
                           image: _image.text,
                           name: _name.text,
                           latitude: selectedMarker.position.latitude,

--- a/lib/views/event/event_creation_view.dart
+++ b/lib/views/event/event_creation_view.dart
@@ -231,7 +231,7 @@ class _FormsColumnState extends State<_FormsColumn> {
             onChanged: (selected) {
               _selectedDatetime = selected;
             },
-            validator: (value) => Validators.validateDateRange(value, loggedUser
+            validator: (value) => Validators.validateDateTimeRange(_selectedDatetime, loggedUser
                         .subscription.maxTimeInAdvanceToCreateEventsInDays),
           ),
           const Text(
@@ -320,9 +320,8 @@ class _FormsColumnState extends State<_FormsColumn> {
                   await notificationService.saveNotification(
                       context, notificationCreacionEvento, event.creator);
 
-                  usersService
-                      .currentUser!.subscription.numEventsCreatedThisMonth++;
-                  usersService.updateProfile();
+                  // ignore: use_build_context_synchronously
+                  await SubscriptionService().updateEventCount(context, event.creator);
 
                   _showInterstitialAd();
 

--- a/lib/views/event/event_creation_view.dart
+++ b/lib/views/event/event_creation_view.dart
@@ -54,7 +54,7 @@ class _EventCreationView extends State<EventCreationView> {
           body: SingleChildScrollView(
               child: Column(children: [
             SizedBox(height: size.height * 0.005),
-            const CustomAd(),
+            const AdPlanLoader(),
             const Center(
                 child: Text(
               'CREAR EVENTO',
@@ -231,8 +231,9 @@ class _FormsColumnState extends State<_FormsColumn> {
             onChanged: (selected) {
               _selectedDatetime = selected;
             },
-            validator: (value) => Validators.validateDateTimeRange(_selectedDatetime, loggedUser
-                        .subscription.maxTimeInAdvanceToCreateEventsInDays),
+            validator: (value) => Validators.validateDateTimeRange(
+                _selectedDatetime,
+                loggedUser.subscription.maxTimeInAdvanceToCreateEventsInDays),
           ),
           const Text(
             "Categorías",
@@ -288,12 +289,12 @@ class _FormsColumnState extends State<_FormsColumn> {
                       latitude: selectedMarker.position.latitude,
                       longitude: selectedMarker.position.longitude,
                       startDate: DateTime.parse(_selectedDatetime!),
-                      visibleFrom: loggedUser.subscription
-                                      .maxVisiblityOfEventsInDays ==
+                      visibleFrom:
+                          loggedUser.subscription.maxVisiblityOfEventsInDays ==
                                   -1
                               ? DateTime.fromMillisecondsSinceEpoch(0)
-                              : DateTime.parse(_selectedDatetime!)
-                                  .subtract(Duration(
+                              : DateTime.parse(_selectedDatetime!).subtract(
+                                  Duration(
                                       days: loggedUser.subscription
                                           .maxVisiblityOfEventsInDays)),
                       tags: await Future.wait(_selectedValues
@@ -309,7 +310,7 @@ class _FormsColumnState extends State<_FormsColumn> {
                             text: "Bienvenido")
                       ],
                       id: const Uuid().v1());
-                      // ignore: use_build_context_synchronously
+                  // ignore: use_build_context_synchronously
                   await eventsService.saveEvent(context, event);
                   final notificationCreacionEvento = ImportantNotification(
                       userId: event.creator,
@@ -321,7 +322,8 @@ class _FormsColumnState extends State<_FormsColumn> {
                       context, notificationCreacionEvento, event.creator);
 
                   // ignore: use_build_context_synchronously
-                  await SubscriptionService().updateEventCount(context, event.creator);
+                  await SubscriptionService()
+                      .updateEventCount(context, event.creator);
 
                   _showInterstitialAd();
 

--- a/lib/views/event/event_details.dart
+++ b/lib/views/event/event_details.dart
@@ -160,17 +160,23 @@ class _FormsColumn extends StatelessWidget {
                 height: 20,
               ),
               if (!selectedEvent.users.contains(activeUserId))
-                SubmitButton(
-                  text: 'Unirse',
-                  onTap: () => {
-                    eventService.addUserToEvent(selectedEvent),
-                    Navigator.pushReplacement(
-                        context,
-                        MaterialPageRoute(
-                            builder: (context) => const EventDetailsView(),
-                            settings: RouteSettings(arguments: selectedEvent)))
-                  },
-                ),
+                if (selectedEvent.isFull)
+                  const Text(
+                    'El evento está lleno',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  )
+                else
+                  SubmitButton(
+                    text: 'Unirse',
+                    onTap: () => {
+                      eventService.addUserToEvent(selectedEvent),
+                      Navigator.pushReplacement(
+                          context,
+                          MaterialPageRoute(
+                              builder: (context) => const EventDetailsView(),
+                              settings: RouteSettings(arguments: selectedEvent)))
+                    },
+                  ),
               if (selectedEvent.users.contains(activeUserId))
                 ElevatedButton(
                   child: const Text('Abrir chat'),

--- a/lib/views/event/event_details.dart
+++ b/lib/views/event/event_details.dart
@@ -1,11 +1,9 @@
+import 'package:findmyfun/models/models.dart';
 import 'package:findmyfun/services/services.dart';
 import 'package:findmyfun/themes/themes.dart';
 import 'package:findmyfun/widgets/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-
-import '../../models/event.dart';
-import '../../models/user.dart';
 
 class EventDetailsView extends StatelessWidget {
   const EventDetailsView({super.key});
@@ -77,12 +75,13 @@ class _FormsColumn extends StatelessWidget {
 
     //print(asistentes);
     String activeUserId = AuthService().currentUser?.uid ?? "";
-    bool isCompany = userService.currentUser!.isCompany == true;
+    late User creatorUser;
 
     return FutureBuilder<User>(
       future: creator,
       builder: (BuildContext context, AsyncSnapshot<User> snapshot) {
         if (snapshot.hasData) {
+          creatorUser = snapshot.data!;
           return Column(
             children: [
               const CustomAd(),
@@ -162,7 +161,7 @@ class _FormsColumn extends StatelessWidget {
               ),
               if (!selectedEvent.users.contains(activeUserId) &&
                   !selectedEvent.isFull &&
-                  !isCompany)
+                  creatorUser.subscription.type != SubscriptionType.company)
                 SubmitButton(
                   text: 'Unirse',
                   onTap: () => {
@@ -187,6 +186,7 @@ class _FormsColumn extends StatelessWidget {
                 builder: (context, snapshot) {
                   if (snapshot.hasData) {
                     final asistentesList = snapshot.data!;
+                    print(asistentesList);
                     return ListView.builder(
                       shrinkWrap: true,
                       physics: const NeverScrollableScrollPhysics(),

--- a/lib/views/event/event_details.dart
+++ b/lib/views/event/event_details.dart
@@ -89,7 +89,7 @@ class _FormsColumn extends StatelessWidget {
           return Column(
             children: [
               SizedBox(height: size.height * 0.005),
-              const CustomAd(),
+              const AdPlanLoader(),
               const SizedBox(
                 height: 10,
               ),
@@ -219,7 +219,6 @@ class _FormsColumn extends StatelessWidget {
                 builder: (context, snapshot) {
                   if (snapshot.hasData) {
                     final asistentesList = snapshot.data!;
-                    print(asistentesList);
                     return ListView.builder(
                       shrinkWrap: true,
                       physics: const NeverScrollableScrollPhysics(),

--- a/lib/views/event/event_details.dart
+++ b/lib/views/event/event_details.dart
@@ -77,6 +77,7 @@ class _FormsColumn extends StatelessWidget {
 
     //print(asistentes);
     String activeUserId = AuthService().currentUser?.uid ?? "";
+    bool isCompany = userService.currentUser!.isCompany == true;
 
     return FutureBuilder<User>(
       future: creator,
@@ -160,11 +161,12 @@ class _FormsColumn extends StatelessWidget {
                 height: 20,
               ),
               if (!selectedEvent.users.contains(activeUserId) &&
-                  !selectedEvent.isFull)
+                  !selectedEvent.isFull &&
+                  !isCompany)
                 SubmitButton(
                   text: 'Unirse',
                   onTap: () => {
-                    eventService.addUserToEvent(selectedEvent),
+                    eventService.addUserToEvent(context, selectedEvent),
                     Navigator.pushReplacement(
                         context,
                         MaterialPageRoute(
@@ -286,7 +288,7 @@ class _FormsColumn extends StatelessWidget {
                 SubmitButton(
                   text: 'Unirse',
                   onTap: () => {
-                    eventService.addUserToEvent(selectedEvent),
+                    eventService.addUserToEvent(context, selectedEvent),
                     Navigator.pushReplacement(
                         context,
                         MaterialPageRoute(

--- a/lib/views/home/events/event_find_view.dart
+++ b/lib/views/home/events/event_find_view.dart
@@ -84,17 +84,33 @@ class _EventFindView extends State<EventFindView> {
                     future: eventsFuture,
                     builder: (context, snapshot) {
                       if (snapshot.hasData) {
-                        return ConstrainedBox(
-                          constraints:
-                              BoxConstraints(maxHeight: size.height * 0.25),
-                          child: ListView.builder(
-                            shrinkWrap: true,
-                            itemCount: snapshot.data!.length,
-                            itemBuilder: (_, index) => EventContainer(
-                              event: snapshot.data![index],
+                        int eventCount = snapshot.data!.length;
+                        if (eventCount == 0) {
+                          return SizedBox(
+                            height: size.height * 0.35,
+                            width: size.width * 0.8,
+                            child: const Center(
+                                child: Text(
+                                    'Ajusta tus preferencias para mostrar eventos recomendados',
+                                    textAlign: TextAlign.center,
+                                    style: TextStyle(
+                                        color: ProjectColors.tertiary,
+                                        fontSize: 20,
+                                        fontWeight: FontWeight.bold))),
+                          );
+                        } else {
+                          return ConstrainedBox(
+                            constraints:
+                                BoxConstraints(maxHeight: size.height * 0.25),
+                            child: ListView.builder(
+                              shrinkWrap: true,
+                              itemCount: snapshot.data!.length,
+                              itemBuilder: (_, index) => EventContainer(
+                                event: snapshot.data![index],
+                              ),
                             ),
-                          ),
-                        );
+                          );
+                        }
                       } else {
                         return Column(children: const [
                           SizedBox(height: 100),

--- a/lib/views/home/events/event_find_view.dart
+++ b/lib/views/home/events/event_find_view.dart
@@ -35,7 +35,7 @@ class _EventFindView extends State<EventFindView> {
         body: Column(
           children: [
             SizedBox(height: size.height * 0.005),
-            const CustomAd(),
+            const AdPlanLoader(),
             SizedBox(
               height: size.height * 0.02,
               width: size.width,
@@ -86,7 +86,7 @@ class _EventFindView extends State<EventFindView> {
                       if (snapshot.hasData) {
                         return ConstrainedBox(
                           constraints:
-                              BoxConstraints(maxHeight: size.height * 0.3),
+                              BoxConstraints(maxHeight: size.height * 0.25),
                           child: ListView.builder(
                             shrinkWrap: true,
                             itemCount: snapshot.data!.length,

--- a/lib/views/home/events/event_list_view.dart
+++ b/lib/views/home/events/event_list_view.dart
@@ -22,7 +22,7 @@ class _EventListView extends State<EventListView> {
 
   _getEvents() async {
     EventsService eventsService = EventsService();
-    return await eventsService.getEvents();
+    return await eventsService.getEventsOfLoggedUser();
   }
 
   @override

--- a/lib/views/home/events/event_list_view.dart
+++ b/lib/views/home/events/event_list_view.dart
@@ -22,7 +22,7 @@ class _EventListView extends State<EventListView> {
 
   _getEvents() async {
     EventsService eventsService = EventsService();
-    return await eventsService.getEventsOfLoggedUser();
+    return await eventsService.getEvents();
   }
 
   @override
@@ -35,10 +35,10 @@ class _EventListView extends State<EventListView> {
           child: Column(
             children: [
               SizedBox(height: size.height * 0.005),
-              const CustomAd(),
+              const AdPlanLoader(),
               const Center(
                   child: Text(
-                'TUS EVENTOS',
+                'TODOS LOS EVENTOS',
                 style: TextStyle(
                     color: ProjectColors.secondary,
                     fontSize: 30,

--- a/lib/views/home/events/event_list_view.dart
+++ b/lib/views/home/events/event_list_view.dart
@@ -37,7 +37,7 @@ class _EventListView extends State<EventListView> {
               CustomAd(width: size.width.floor()),
               const Center(
                   child: Text(
-                'TODOS LOS EVENTOS',
+                'TUS EVENTOS',
                 style: TextStyle(
                     color: ProjectColors.secondary,
                     fontSize: 30,

--- a/lib/views/home/events/event_list_view.dart
+++ b/lib/views/home/events/event_list_view.dart
@@ -22,7 +22,7 @@ class _EventListView extends State<EventListView> {
 
   _getEvents() async {
     EventsService eventsService = EventsService();
-    return await eventsService.getEvents();
+    return await eventsService.getEventsOfLoggedUser();
   }
 
   @override
@@ -38,7 +38,7 @@ class _EventListView extends State<EventListView> {
               const AdPlanLoader(),
               const Center(
                   child: Text(
-                'TODOS LOS EVENTOS',
+                'TUS EVENTOS',
                 style: TextStyle(
                     color: ProjectColors.secondary,
                     fontSize: 30,
@@ -48,16 +48,32 @@ class _EventListView extends State<EventListView> {
                 future: eventsFuture,
                 builder: (context, snapshot) {
                   if (snapshot.hasData) {
-                    return ConstrainedBox(
-                      constraints:
-                          BoxConstraints(maxHeight: size.height * 0.68),
-                      child: ListView.builder(
-                        itemCount: snapshot.data!.length,
-                        itemBuilder: (_, index) => EventContainer(
-                          event: snapshot.data![index],
+                    int eventCount = snapshot.data!.length;
+                    if (eventCount == 0) {
+                      return SizedBox(
+                        height: size.height * 0.6,
+                        width: size.width * 0.8,
+                        child: const Center(
+                            child: Text(
+                                'No estás en ningún evento, crea o únete a uno',
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                    color: ProjectColors.tertiary,
+                                    fontSize: 20,
+                                    fontWeight: FontWeight.bold))),
+                      );
+                    } else {
+                      return ConstrainedBox(
+                        constraints:
+                            BoxConstraints(maxHeight: size.height * 0.68),
+                        child: ListView.builder(
+                          itemCount: snapshot.data!.length,
+                          itemBuilder: (_, index) => EventContainer(
+                            event: snapshot.data![index],
+                          ),
                         ),
-                      ),
-                    );
+                      );
+                    }
                   } else {
                     return Column(children: const [
                       SizedBox(height: 100),

--- a/lib/views/home/events/event_search_view.dart
+++ b/lib/views/home/events/event_search_view.dart
@@ -36,7 +36,7 @@ class _EventSearchViewState extends State<EventSearchView> {
           child: Column(
             children: [
               SizedBox(height: size.height * 0.005),
-              const CustomAd(),
+              const AdPlanLoader(),
               const Center(
                   child: Text(
                 'BUSCAR EVENTOS',

--- a/lib/views/home/notifications/notifications_view.dart
+++ b/lib/views/home/notifications/notifications_view.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:findmyfun/services/auth_service.dart';
 import 'package:findmyfun/services/important_notification_service.dart';
 import 'package:findmyfun/themes/colors.dart';
@@ -49,7 +48,7 @@ class _NotificationViewState extends State<NotificationView> {
                 Container(
                   alignment: Alignment.center,
                   margin: const EdgeInsets.all(20),
-                  child: Text(
+                  child: const Text(
                     'No tienes notificaciones',
                     textAlign: TextAlign.center,
                     style: TextStyle(fontSize: 25, fontWeight: FontWeight.bold),

--- a/lib/views/home/profile/eventcreator_profile_view.dart
+++ b/lib/views/home/profile/eventcreator_profile_view.dart
@@ -1,12 +1,9 @@
 import 'package:findmyfun/models/models.dart';
 import 'package:findmyfun/themes/colors.dart';
 import 'package:findmyfun/themes/styles.dart';
-import 'package:findmyfun/widgets/custom_banner_ad.dart';
-import 'package:findmyfun/widgets/custom_text_form.dart';
+import 'package:findmyfun/widgets/widgets.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:findmyfun/services/services.dart';
 
 class EventCreatorProfileDetailsView extends StatelessWidget {
   const EventCreatorProfileDetailsView({super.key});
@@ -42,7 +39,7 @@ class EventCreatorProfileDetailsView extends StatelessWidget {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                CustomAd(width: size.width.floor()),
+                const AdPlanLoader(),
                 Container(
                     padding: const EdgeInsets.all(10.0),
                     // child: Image.network(currentUser.image!, fit: BoxFit.cover),

--- a/lib/views/home/profile/profile_details_view.dart
+++ b/lib/views/home/profile/profile_details_view.dart
@@ -2,14 +2,11 @@
 
 import 'package:findmyfun/models/models.dart';
 import 'package:findmyfun/themes/styles.dart';
-import 'package:findmyfun/widgets/custom_banner_ad.dart';
-import 'package:findmyfun/widgets/custom_text_details.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:findmyfun/services/services.dart';
-
-import '../../../widgets/custom_button.dart';
+import 'package:findmyfun/widgets/widgets.dart';
 
 class ProfileDetailsView extends StatelessWidget {
   const ProfileDetailsView({super.key});
@@ -18,7 +15,6 @@ class ProfileDetailsView extends StatelessWidget {
   Widget build(BuildContext context) {
     final userService = Provider.of<UsersService>(context);
     final currentUser = userService.currentUser!;
-    final size = MediaQuery.of(context).size;
 
     return Scaffold(
       appBar: AppBar(
@@ -38,7 +34,7 @@ class ProfileDetailsView extends StatelessWidget {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                const CustomAd(),
+                const AdPlanLoader(),
                 Container(
                     padding: const EdgeInsets.all(10.0),
                     // child: Image.network(currentUser.image!, fit: BoxFit.cover),
@@ -136,7 +132,8 @@ class ProfileDetailsView extends StatelessWidget {
                   endIndent: 20,
                 ),
                 Visibility(
-                  visible: currentUser.subscription.type == SubscriptionType.company,
+                  visible:
+                      currentUser.subscription.type == SubscriptionType.company,
                   child: GestureDetector(
                       onTap: () async {
                         await AuthService().signOut();

--- a/lib/views/home/profile/profile_details_view.dart
+++ b/lib/views/home/profile/profile_details_view.dart
@@ -136,7 +136,7 @@ class ProfileDetailsView extends StatelessWidget {
                   endIndent: 20,
                 ),
                 Visibility(
-                  visible: currentUser.isCompany ?? false,
+                  visible: currentUser.subscription.type == SubscriptionType.company,
                   child: GestureDetector(
                       onTap: () async {
                         await AuthService().signOut();

--- a/lib/views/register/register_view_form.dart
+++ b/lib/views/register/register_view_form.dart
@@ -134,7 +134,12 @@ class _RegisterFormContainerState extends State<_RegisterFormContainer> {
                     preferences: [
                       models.Preferences(id: '0001', name: 'Preferencia')
                     ],
-                    notifications: [],
+                    notifications: [
+                      models.ImportantNotification(
+                          date: DateTime.now(),
+                          userId: credential.user!.uid,
+                          info: 'Bienvenido'),
+                    ],
                     subscription: models.Subscription(
                         type: models.SubscriptionType.free,
                         numEventsCreatedThisMonth: 0));

--- a/lib/views/register/register_view_plan.dart
+++ b/lib/views/register/register_view_plan.dart
@@ -73,7 +73,6 @@ class _RegisterFormContainerState extends State<_RegisterFormContainer> {
             final userService =
                 Provider.of<UsersService>(context, listen: false);
             if (userService.currentUser != null) {
-              userService.currentUser!.isCompany = true;
               userService.currentUser!.subscription.type = SubscriptionType.company;
               userService.currentUser!.subscription.validUntil = DateTime.now().add(const Duration(days: 30));
               await userService.addItem(userService.currentUser!);

--- a/lib/views/register/register_view_plan.dart
+++ b/lib/views/register/register_view_plan.dart
@@ -1,3 +1,4 @@
+import 'package:findmyfun/models/models.dart';
 import 'package:findmyfun/services/services.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -73,6 +74,8 @@ class _RegisterFormContainerState extends State<_RegisterFormContainer> {
                 Provider.of<UsersService>(context, listen: false);
             if (userService.currentUser != null) {
               userService.currentUser!.isCompany = true;
+              userService.currentUser!.subscription.type = SubscriptionType.company;
+              userService.currentUser!.subscription.validUntil = DateTime.now().add(const Duration(days: 30));
               await userService.addItem(userService.currentUser!);
             }
           }

--- a/lib/views/settings/settings_view.dart
+++ b/lib/views/settings/settings_view.dart
@@ -5,6 +5,8 @@ import 'package:findmyfun/widgets/custom_button.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../models/models.dart';
+
 class SettingsView extends StatelessWidget {
   const SettingsView({Key? key}) : super(key: key);
 
@@ -41,7 +43,7 @@ class SettingsView extends StatelessWidget {
               child: const CustomButton(text: 'Eventos registrados')),
         ),
         Visibility(
-          visible: user.isCompany ?? false,
+          visible: user.subscription.type == SubscriptionType.company,
           child: GestureDetector(
               onTap: () async {
                 await AuthService().signOut();

--- a/lib/widgets/ad_plan_loader.dart
+++ b/lib/widgets/ad_plan_loader.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+import 'package:findmyfun/models/models.dart';
+import 'package:findmyfun/services/services.dart';
+import 'package:findmyfun/widgets/widgets.dart';
+import 'package:flutter/material.dart';
+
+class AdPlanLoader extends StatefulWidget {
+  const AdPlanLoader({Key? key}) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => _AdPlanLoaderState();
+}
+
+class _AdPlanLoaderState extends State<AdPlanLoader> {
+  late Future<User> loggedUserFuture;
+
+  Future<User> getLoggedUser() async {
+    User user = await UsersService()
+        .getUserWithUid(AuthService().currentUser?.uid ?? "");
+    return user;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    loggedUserFuture = getLoggedUser();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<User>(
+      future: loggedUserFuture,
+      builder: (context, snapshot) {
+        if (snapshot.hasData) {
+          if (snapshot.data!.subscription.type == SubscriptionType.free) {
+            return const CustomAd();
+          } else {
+            return const SizedBox.shrink();
+          }
+        } else {
+          return const SizedBox.shrink();
+        }
+      },
+    );
+  }
+}

--- a/lib/widgets/custom_button.dart
+++ b/lib/widgets/custom_button.dart
@@ -1,4 +1,3 @@
-import 'package:findmyfun/themes/colors.dart';
 import 'package:flutter/material.dart';
 
 class CustomButton extends StatelessWidget {

--- a/lib/widgets/custom_text_form.dart
+++ b/lib/widgets/custom_text_form.dart
@@ -53,6 +53,7 @@ class CustomTextForm extends StatelessWidget {
           hintStyle: const TextStyle(
               color: Color.fromARGB(221, 90, 87, 87), fontSize: 26),
           border: InputBorder.none,
+          errorStyle: const TextStyle(color: Color.fromARGB(255, 243, 37, 22)),
         ),
       ),
     );

--- a/lib/widgets/event_container.dart
+++ b/lib/widgets/event_container.dart
@@ -54,7 +54,9 @@ class EventContainer extends StatelessWidget {
                         const SizedBox(
                           height: 10,
                         ),
-                        Text('${event.users.length} asistente/s'),
+                        event.maxUsers != -1
+                        ? Text('${event.users.length}/${event.maxUsers} asistentes')
+                        : Text('${event.users.length} asistente/s'),
                       ],
                     )),
                 const SizedBox(

--- a/lib/widgets/event_creator.dart
+++ b/lib/widgets/event_creator.dart
@@ -1,7 +1,5 @@
-import 'package:findmyfun/screens/screens.dart';
 import 'package:flutter/material.dart';
 import 'package:findmyfun/widgets/widgets.dart';
-import 'package:findmyfun/models/event.dart';
 import 'package:provider/provider.dart';
 
 import '../models/models.dart';

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -15,3 +15,4 @@ export 'package:findmyfun/widgets/event_creator.dart';
 export 'package:findmyfun/widgets/custom_checkbox.dart';
 export 'package:findmyfun/widgets/category_dropdown.dart';
 export 'package:findmyfun/widgets/custom_banner_ad.dart';
+export 'package:findmyfun/widgets/ad_plan_loader.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -763,5 +763,5 @@ packages:
     source: hosted
     version: "1.0.0"
 sdks:
-  dart: ">=2.19.0-444.4.beta <3.0.0"
+  dart: ">=2.19.0-444.4.beta <4.0.0"
   flutter: ">=3.3.0"


### PR DESCRIPTION
- En la pantalla inicial solo se muestran los eventos del usuario logueado.
- Cuando se registra un usuario en modo empresa, se crea con el tipo company.
- En el listado de eventos, se muestra el límite de usuarios de cada evento de la forma '<usuarios/límite> asistentes'. De no haber límite, se muestra de la forma '<usuarios> asistente/s'.
- Limita el número de usuarios que se pueden unir a un evento.
- En findEvents, solo se muestran los eventos que tienen preferencias en común, no han terminado, son visibles, no están llenos y el usuario no está dentro.
- En el mapa salen los eventos no terminados, visibles, no están llenos (a no ser que el usuario esté dentro).
- Cuando creas un evento debe pasar lo siguiente:
  - Se actualiza el contador de eventos creados del creador.
  - Al evento se le asigna el número máximo de usuarios (dependiendo del plan del creador).
  - Al evento se le asigna la fecha de visiblidad (dependiendo del plan del creador).
  - Solo se puede crear un evento con fecha en el futuro y con la antelación máxima (dependiendo del plan del creador).
- Solo se deben mostrar anuncios a los usuarios free.
- Si no se encuentra ningún evento para listar, la app muestra un mensaje al usuario indicándole que hacer para que se muestren (Crear/añadirse a un evento, ajustar las preferencias...).
- Cuando un usuario se une a un evento, se deben crear dos notificaciones; una en el usuario que creó el evento y otra en el que se une.