### PR TITLE
Resuelve conflicto entre llamadas asíncronas

### DIFF
--- a/lib/services/users_service.dart
+++ b/lib/services/users_service.dart
@@ -118,6 +118,21 @@ class UsersService extends ChangeNotifier {
     }
   }
 
+  //UPDATE PROFILE
+  Future<bool> updateUser(User user) async {
+    final url = Uri.https(_baseUrl, 'Users/${currentUser!.id}.json');
+    try {
+      // ignore: unused_local_variable
+      final resp = await http.put(url, body: jsonEncode(user.toJson()));
+
+      if (resp.statusCode != 200) return false;
+      return true;
+    } catch (e) {
+      debugPrint('Error editing profile: $e');
+      return false;
+    }
+  }
+
   //DELETE PROFILE
   Future<void> deleteProfile(User user, BuildContext context) async {
     final url = Uri.https(_baseUrl, 'Users/${user.id}.json');

--- a/lib/views/event/event_creation_view.dart
+++ b/lib/views/event/event_creation_view.dart
@@ -325,13 +325,9 @@ class _FormsColumnState extends State<_FormsColumn> {
                       date: DateTime.now(),
                       info: "Has creado correctamente el evento ${event.name}");
 
-                  // ignore: use_build_context_synchronously
-                  await notificationService.saveNotification(
-                      context, notificationCreacionEvento, event.creator);
-
-                  // ignore: use_build_context_synchronously
-                  await SubscriptionService()
-                      .updateEventCount(context, event.creator);
+                  loggedUser.notifications.add(notificationCreacionEvento);
+                  loggedUser.subscription.numEventsCreatedThisMonth++;
+                  await usersService.updateUser(loggedUser);
 
                   _showInterstitialAd();
 


### PR DESCRIPTION
- Cuando se cree un evento se debe añadir una notificación al usuario creador.
- De igual modo, se debe incrementar en una unidad el conteo de eventos creados este mes.