### PR TITLE
fix: Arreglo de la modificación de usuario

### DIFF
--- a/lib/views/home/profile/profile_details_view.dart
+++ b/lib/views/home/profile/profile_details_view.dart
@@ -154,22 +154,30 @@ class _ProfileDetailsViewState extends State<ProfileDetailsView> {
                   indent: 20,
                   endIndent: 20,
                 ),
-                const Text(
-                  "Válido hasta",
-                  textAlign: TextAlign.center,
-                  style: TextStyle(fontSize: 25, fontWeight: FontWeight.w800),
-                ),
-                CustomTextDetail(
-                  hintText: currentUser.subscription.validUntil.toString(),
-                  initialValue: currentUser.subscription.validUntil.toString(),
-                  enabled: false,
-                ),
-                const Divider(
-                  color: Colors.grey,
-                  thickness: 0.5,
-                  height: 20,
-                  indent: 20,
-                  endIndent: 20,
+                Visibility(
+                  visible: currentUser.subscription.type != SubscriptionType.free,
+                  child: 
+                    Column(
+                      children: [
+                        const Text(
+                          "Válido hasta",
+                          textAlign: TextAlign.center,
+                          style: TextStyle(fontSize: 25, fontWeight: FontWeight.w800),
+                        ),
+                        CustomTextDetail(
+                          hintText: currentUser.subscription.validUntil.toString(),
+                          initialValue: currentUser.subscription.validUntil.toString(),
+                          enabled: false,
+                        ),
+                        const Divider(
+                          color: Colors.grey,
+                          thickness: 0.5,
+                          height: 20,
+                          indent: 20,
+                          endIndent: 20,
+                        ),
+                      ],
+                    )
                 ),
                 Visibility(
                   visible:

--- a/lib/views/home/profile/profile_details_view.dart
+++ b/lib/views/home/profile/profile_details_view.dart
@@ -8,9 +8,14 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:findmyfun/services/services.dart';
 import 'package:findmyfun/widgets/widgets.dart';
 
-class ProfileDetailsView extends StatelessWidget {
+class ProfileDetailsView extends StatefulWidget {
   const ProfileDetailsView({super.key});
 
+  @override
+  State<ProfileDetailsView> createState() => _ProfileDetailsViewState();
+}
+
+class _ProfileDetailsViewState extends State<ProfileDetailsView> {
   @override
   Widget build(BuildContext context) {
     final userService = Provider.of<UsersService>(context);
@@ -138,7 +143,8 @@ class ProfileDetailsView extends StatelessWidget {
                 ),
                 CustomTextDetail(
                   hintText: getSuscriptionType(currentUser.subscription.type),
-                  initialValue: getSuscriptionType(currentUser.subscription.type),
+                  initialValue:
+                      getSuscriptionType(currentUser.subscription.type),
                   enabled: false,
                 ),
                 const Divider(
@@ -312,14 +318,14 @@ class _DeleteProfile extends State<DeleteProfile> {
   }
 }
 
-String getSuscriptionType(SubscriptionType type){
-    String suscription = "";
-    if(type == SubscriptionType.free){
-      suscription = "Gratuita";
-    } else if(type == SubscriptionType.premium){
-      suscription = "Premium";
-    } else if(type == SubscriptionType.company){
-      suscription = "Empresa";
-    } 
-    return suscription;
+String getSuscriptionType(SubscriptionType type) {
+  String suscription = "";
+  if (type == SubscriptionType.free) {
+    suscription = "Gratuita";
+  } else if (type == SubscriptionType.premium) {
+    suscription = "Premium";
+  } else if (type == SubscriptionType.company) {
+    suscription = "Empresa";
   }
+  return suscription;
+}

--- a/lib/views/home/profile/profile_edit_view.dart
+++ b/lib/views/home/profile/profile_edit_view.dart
@@ -10,6 +10,7 @@ import '../../../services/services.dart';
 import '../../../themes/colors.dart';
 import '../../../themes/styles.dart';
 import '../../../widgets/widgets.dart';
+import '../../views.dart';
 
 class ProfileEditForm extends StatelessWidget {
   const ProfileEditForm({
@@ -150,7 +151,7 @@ class _ProfileEditFormState extends State<_ProfileEditForm> {
           text: 'MODIFICAR',
           onTap: () async {
             if (_formKey.currentState!.validate()) {
-              try {
+              // try {
                 showDialog(
                   context: context,
                   builder: (context) => Column(
@@ -190,27 +191,31 @@ class _ProfileEditFormState extends State<_ProfileEditForm> {
                     preferences: currentUser.preferences,
                     notifications: currentUser.notifications,
                     subscription: currentUser.subscription);
-                final resp = await userService.updateProfile();
+                final resp = await userService.updateProfileAdmin(userService.currentUser!);
                 if (resp) {
                   print(_nameController.text);
                   Navigator.pop(context);
                   Navigator.pop(context);
+                  // Navigator.pushReplacement(
+                  //   context,
+                  //   MaterialPageRoute(builder: (context) => ProfileDetailsView()),
+                  //   );
                 } else {
                   Navigator.pop(context);
                   _formKey.currentState!.validate();
                   print('Error al editar el usuario');
                 }
                 print('Usuario modificado con uid: ${currentUser.id}');
-              } on FirebaseAuthException {
-                Navigator.pop(context);
-                showExceptionDialog(context);
-              } on FirebaseException {
-                Navigator.pop(context);
-                showExceptionDialog(context);
-              } catch (e) {
-                Navigator.pop(context);
-                showExceptionDialog(context);
-              }
+              // } on FirebaseAuthException {
+              //   Navigator.pop(context);
+              //   showExceptionDialog(context);
+              // } on FirebaseException {
+              //   Navigator.pop(context);
+              //   showExceptionDialog(context);
+              // } catch (e) {
+              //   Navigator.pop(context);
+              //   showExceptionDialog(context);
+              // }
             }
           },
         )

--- a/lib/views/home/profile/profile_edit_view.dart
+++ b/lib/views/home/profile/profile_edit_view.dart
@@ -2,7 +2,6 @@
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:findmyfun/models/models.dart' as user;
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -10,7 +9,6 @@ import '../../../services/services.dart';
 import '../../../themes/colors.dart';
 import '../../../themes/styles.dart';
 import '../../../widgets/widgets.dart';
-import '../../views.dart';
 
 class ProfileEditForm extends StatelessWidget {
   const ProfileEditForm({
@@ -35,7 +33,6 @@ class ProfileEditForm extends StatelessWidget {
           'EDITAR PERFIL',
           textAlign: TextAlign.center,
           style: Styles.appBar,
-          
         ),
       ),
       body: Center(
@@ -152,60 +149,60 @@ class _ProfileEditFormState extends State<_ProfileEditForm> {
           onTap: () async {
             if (_formKey.currentState!.validate()) {
               // try {
-                showDialog(
-                  context: context,
-                  builder: (context) => Column(
-                      mainAxisSize: MainAxisSize.min,
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: const [
-                        SizedBox(
-                            height: 50,
-                            width: 50,
-                            child: CircularProgressIndicator()),
-                      ]),
-                );
+              showDialog(
+                context: context,
+                builder: (context) => Column(
+                    mainAxisSize: MainAxisSize.min,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: const [
+                      SizedBox(
+                          height: 50,
+                          width: 50,
+                          child: CircularProgressIndicator()),
+                    ]),
+              );
 
-                if (_usernameController.text == "") {
-                  _usernameController.text = currentUser.username;
-                }
-                if (_nameController.text == "") {
-                  _nameController.text = currentUser.name;
-                }
-                if (_surnameController.text == "") {
-                  _surnameController.text = currentUser.surname;
-                }
-                if (_cityController.text == "") {
-                  _cityController.text = currentUser.city;
-                }
-                if (_imageController.text == "") {
-                  _imageController.text = currentUser.image!;
-                }
-                userService.currentUser = user.User(
-                    id: currentUser.id,
-                    image: _imageController.text,
-                    name: _nameController.text,
-                    surname: _surnameController.text,
-                    username: _usernameController.text,
-                    city: _cityController.text,
-                    email: currentUser.email,
-                    preferences: currentUser.preferences,
-                    notifications: currentUser.notifications,
-                    subscription: currentUser.subscription);
-                final resp = await userService.updateProfileAdmin(userService.currentUser!);
-                if (resp) {
-                  print(_nameController.text);
-                  Navigator.pop(context);
-                  Navigator.pop(context);
-                  // Navigator.pushReplacement(
-                  //   context,
-                  //   MaterialPageRoute(builder: (context) => ProfileDetailsView()),
-                  //   );
-                } else {
-                  Navigator.pop(context);
-                  _formKey.currentState!.validate();
-                  print('Error al editar el usuario');
-                }
-                print('Usuario modificado con uid: ${currentUser.id}');
+              if (_usernameController.text == "") {
+                _usernameController.text = currentUser.username;
+              }
+              if (_nameController.text == "") {
+                _nameController.text = currentUser.name;
+              }
+              if (_surnameController.text == "") {
+                _surnameController.text = currentUser.surname;
+              }
+              if (_cityController.text == "") {
+                _cityController.text = currentUser.city;
+              }
+              if (_imageController.text == "") {
+                _imageController.text = currentUser.image!;
+              }
+              userService.currentUser = user.User(
+                  id: currentUser.id,
+                  image: _imageController.text,
+                  name: _nameController.text,
+                  surname: _surnameController.text,
+                  username: _usernameController.text,
+                  city: _cityController.text,
+                  email: currentUser.email,
+                  preferences: currentUser.preferences,
+                  notifications: currentUser.notifications,
+                  subscription: currentUser.subscription);
+              final resp = await userService
+                  .updateProfileAdmin(userService.currentUser!);
+              if (resp) {
+                print(_nameController.text);
+                Navigator.pop(context);
+                Navigator.pop(context);
+                Provider.of<PageViewService>(context, listen: false)
+                    .mainPageController
+                    .jumpToPage(0);
+              } else {
+                Navigator.pop(context);
+                _formKey.currentState!.validate();
+                print('Error al editar el usuario');
+              }
+              print('Usuario modificado con uid: ${currentUser.id}');
               // } on FirebaseAuthException {
               //   Navigator.pop(context);
               //   showExceptionDialog(context);


### PR DESCRIPTION
No ha habido manera de recargar la pagina del perfil una vez se modifican los datos, así la medida que hemos tomado ha sido la de una vez modificados los datos, redireccionar a la página inicial, haciendo que una vez navegues a tu perfil para comprobar si se han modificado los datos, se busquen los datos del usuario cuando se carga la vista, actualizando sus datos