### PR TITLE
feat: Implementación de la caducidad de los planes de pago

### DIFF
--- a/lib/models/event_point.dart
+++ b/lib/models/event_point.dart
@@ -5,7 +5,6 @@
 import 'dart:convert';
 
 class EventPoint {
-
   EventPoint({
     required this.name,
     required this.description,
@@ -16,6 +15,8 @@ class EventPoint {
     required this.country,
     required this.image,
     required this.id,
+    required this.visible,
+    required this.creatorId,
   });
 
   String name;
@@ -27,6 +28,8 @@ class EventPoint {
   String country;
   String image;
   String id;
+  bool visible;
+  String creatorId;
 
   factory EventPoint.fromRawJson(String str) =>
       EventPoint.fromJson(json.decode(str));
@@ -34,17 +37,17 @@ class EventPoint {
   String toRawJson() => json.encode(toJson());
 
   factory EventPoint.fromJson(Map<String, dynamic> json) => EventPoint(
-        name: json["name"],
-        description: json["description"],
-        longitude: json["longitude"].toDouble(),
-        latitude: json["latitude"].toDouble(),
-        address: json["address"],
-        city: json["city"],
-        country: json["country"],
-        image: json["image"],
-        id: json["id"],
-    );
-
+      name: json["name"],
+      description: json["description"],
+      longitude: json["longitude"].toDouble(),
+      latitude: json["latitude"].toDouble(),
+      address: json["address"],
+      city: json["city"],
+      country: json["country"],
+      image: json["image"],
+      id: json["id"],
+      visible: json["visible"] ?? true,
+      creatorId: json["creatorId"]);
 
   Map<String, dynamic> toJson() => {
         "name": name,
@@ -56,6 +59,8 @@ class EventPoint {
         "country": country,
         "image": image,
         "id": id,
+        "visible": visible,
+        "creatorId": creatorId,
       };
 
   @override

--- a/lib/models/subscription.dart
+++ b/lib/models/subscription.dart
@@ -6,11 +6,13 @@ class Subscription {
   Subscription(
       {required this.type,
       this.validUntil,
-      required this.numEventsCreatedThisMonth});
+      required this.numEventsCreatedThisMonth,
+      required this.lastReset});
 
   SubscriptionType type;
   DateTime? validUntil;
   int numEventsCreatedThisMonth = 0;
+  DateTime lastReset;
 
   int get maxEventsPerMonth => type == SubscriptionType.free
       ? 5
@@ -39,6 +41,12 @@ class Subscription {
   bool get canCreateEvents =>
       maxEventsPerMonth == -1 || numEventsCreatedThisMonth < maxEventsPerMonth;
 
+  bool get isExpired =>
+      validUntil != null && validUntil!.isBefore(DateTime.now());
+
+  bool get needsReset =>
+      lastReset.isBefore(DateTime.now().subtract(const Duration(days: 30)));
+
   factory Subscription.fromRawJson(String str) =>
       Subscription.fromJson(json.decode(str));
 
@@ -50,21 +58,28 @@ class Subscription {
             ? DateTime.parse(json["validUntil"])
             : null,
         numEventsCreatedThisMonth: json['numEventsCreatedThisMonth'] ?? 0,
+        lastReset: json["lastReset"] != null
+            ? DateTime.parse(json["lastReset"])
+            : DateTime.fromMillisecondsSinceEpoch(0),
       );
 
   Map<String, dynamic> toJson() => {
         "type": type.index,
         "validUntil": validUntil?.toIso8601String(),
         "numEventsCreatedThisMonth": numEventsCreatedThisMonth,
+        "lastReset": lastReset.toIso8601String(),
       };
 
   @override
   String toString() =>
-      'type: $type, validUntil: $validUntil?, numEventsCreatedThisMonth: $numEventsCreatedThisMonth';
+      'type: $type, validUntil: $validUntil?, numEventsCreatedThisMonth: $numEventsCreatedThisMonth, lastReset: $lastReset';
 
   @override
   int get hashCode =>
-      type.hashCode ^ validUntil.hashCode ^ numEventsCreatedThisMonth.hashCode;
+      type.hashCode ^
+      validUntil.hashCode ^
+      numEventsCreatedThisMonth.hashCode ^
+      lastReset.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -73,5 +88,6 @@ class Subscription {
           runtimeType == other.runtimeType &&
           type == other.type &&
           validUntil == other.validUntil &&
-          numEventsCreatedThisMonth == other.numEventsCreatedThisMonth;
+          numEventsCreatedThisMonth == other.numEventsCreatedThisMonth &&
+          lastReset == other.lastReset;
 }

--- a/lib/screens/event_point_creation_screen.dart
+++ b/lib/screens/event_point_creation_screen.dart
@@ -228,7 +228,9 @@ class _EventPointCreationScreenState extends State<EventPointCreationScreen> {
                                     city: placeMark.locality!,
                                     country: placeMark.country!,
                                     image: imageUrl,
-                                    id: eventPointId);
+                                    id: eventPointId,
+                                    visible: true,
+                                    creatorId: usersService.currentUser!.id);
                                 showCircularProgressDialog(context);
                                 await eventPointsService.saveEventPoint(
                                     eventPoint, usersService.currentUser!);

--- a/lib/services/event_points_service.dart
+++ b/lib/services/event_points_service.dart
@@ -95,4 +95,53 @@ class EventPointsService extends ChangeNotifier {
       throw Exception('Error getting event points: $e');
     }
   }
+
+  // GET EVENT POINTS FROM USER
+  Future<List<EventPoint>> getEventPointsFromUser(User user) async {
+    final url = Uri.https(_baseUrl, 'EventPoints.json');
+    try {
+      final resp = await http.get(url);
+      if (resp.statusCode != 200) {
+        throw Exception('Error in response');
+      }
+
+      final Map<String, dynamic> data = jsonDecode(resp.body);
+
+      final List<EventPoint> eventPoints = [];
+      data.forEach((key, value) {
+        try {
+          final eventPoint = EventPoint.fromJson(value);
+          if (eventPoint.creatorId == user.id) {
+            eventPoints.add(eventPoint);
+          }
+        } catch (e) {
+          debugPrint('Error parsing event point: $e');
+        }
+      });
+
+      return eventPoints;
+    } catch (e) {
+      throw Exception('Error getting event points: $e');
+    }
+  }
+
+  // SET USER'S EVENTO POINTS TO INVISIBLE
+  Future<void> setUsersEventPointsToInvisible(User user) async {
+    List<EventPoint> eventPoints = await getEventPointsFromUser(user);
+
+    for (EventPoint eventPoint in eventPoints) {
+      eventPoint.visible = false;
+      await saveEventPoint(eventPoint, user);
+    }
+  }
+
+  // SET USER'S EVENTO POINTS TO VISIBLE
+  Future<void> setUsersEventPointsToVisible(User user) async {
+    List<EventPoint> eventPoints = await getEventPointsFromUser(user);
+
+    for (EventPoint eventPoint in eventPoints) {
+      eventPoint.visible = true;
+      await saveEventPoint(eventPoint, user);
+    }
+  }
 }

--- a/lib/services/event_points_service.dart
+++ b/lib/services/event_points_service.dart
@@ -130,6 +130,7 @@ class EventPointsService extends ChangeNotifier {
     List<EventPoint> eventPoints = await getEventPointsFromUser(user);
 
     for (EventPoint eventPoint in eventPoints) {
+      if (eventPoint.visible == false) continue;
       eventPoint.visible = false;
       await saveEventPoint(eventPoint, user);
     }
@@ -140,6 +141,7 @@ class EventPointsService extends ChangeNotifier {
     List<EventPoint> eventPoints = await getEventPointsFromUser(user);
 
     for (EventPoint eventPoint in eventPoints) {
+      if (eventPoint.visible == true) continue;
       eventPoint.visible = true;
       await saveEventPoint(eventPoint, user);
     }

--- a/lib/services/map_service.dart
+++ b/lib/services/map_service.dart
@@ -34,6 +34,7 @@ class MapService extends ChangeNotifier {
     }
 
     for (var eventPoint in eventPoints) {
+      if (!eventPoint.visible) continue;
       markers.add(Point(
           event: eventPoint,
           marker: Marker(

--- a/lib/services/subscription_service.dart
+++ b/lib/services/subscription_service.dart
@@ -48,6 +48,9 @@ class SubscriptionService extends ChangeNotifier {
   }
 
   Future<User> changePlanToFree(User user, {bool expired = false}) async {
+    // Set all the event points to invisible
+    await eventPointsService.setUsersEventPointsToInvisible(user);
+
     user.subscription.type = SubscriptionType.free;
     user.subscription.numEventsCreatedThisMonth = 0;
     user.subscription.validUntil = null;
@@ -70,15 +73,15 @@ class SubscriptionService extends ChangeNotifier {
       user.notifications.add(notification);
     }
 
-    // Set all the event points to invisible
-    eventPointsService.setUsersEventPointsToInvisible(user);
-
     await usersService.addItem(user);
 
     return user;
   }
 
   Future<User> changePlanToPremium(User user) async {
+    // Set all the event points to invisible
+    await eventPointsService.setUsersEventPointsToInvisible(user);
+
     user.subscription.type = SubscriptionType.premium;
     user.subscription.numEventsCreatedThisMonth = 0;
     user.subscription.validUntil = DateTime.now().add(const Duration(days: 30));
@@ -90,9 +93,6 @@ class SubscriptionService extends ChangeNotifier {
         date: DateTime.now(),
         info: "Su subcripción se acaba de cambiar al plan premium.");
     user.notifications.add(notification);
-
-    // Set all the event points to invisible
-    eventPointsService.setUsersEventPointsToInvisible(user);
 
     await usersService.addItem(user);
 
@@ -113,7 +113,7 @@ class SubscriptionService extends ChangeNotifier {
     user.notifications.add(notification);
 
     // Set all the event points to visible
-    eventPointsService.setUsersEventPointsToVisible(user);
+    await eventPointsService.setUsersEventPointsToVisible(user);
 
     await usersService.addItem(user);
 

--- a/lib/services/subscription_service.dart
+++ b/lib/services/subscription_service.dart
@@ -10,6 +10,7 @@ import 'package:provider/provider.dart';
 class SubscriptionService extends ChangeNotifier {
   final String _baseUrl = 'findmyfun-c0acc-default-rtdb.firebaseio.com';
   final UsersService usersService = UsersService();
+  final EventPointsService eventPointsService = EventPointsService();
   final currentAuthUser = AuthService().currentUser;
 
   //UPDATE PROFILE
@@ -30,27 +31,103 @@ class SubscriptionService extends ChangeNotifier {
     }
   }
 
-  Future<void> changePlanToFree(User user) async {
+  Future<User> resetSubscription(User user) {
+    user.subscription.numEventsCreatedThisMonth = 0;
+    user.subscription.lastReset = DateTime.now();
+
+    // Add a notification to the user
+    ImportantNotification notification = ImportantNotification(
+        userId: user.id,
+        date: DateTime.now(),
+        info: "Se ha reiniciado su contador de eventos creados.");
+    user.notifications.add(notification);
+
+    usersService.addItem(user);
+
+    return Future.value(user);
+  }
+
+  Future<User> changePlanToFree(User user, {bool expired = false}) async {
     user.subscription.type = SubscriptionType.free;
     user.subscription.numEventsCreatedThisMonth = 0;
     user.subscription.validUntil = null;
+    user.subscription.lastReset = DateTime.now();
+
+    if (expired) {
+      // Add a notification to the user
+      ImportantNotification notification = ImportantNotification(
+          userId: user.id,
+          date: DateTime.now(),
+          info:
+              "Tu suscripción ha terminado y se ha cambiado automáticamente al plan gratuito.");
+      user.notifications.add(notification);
+    } else {
+      // Add a notification to the user
+      ImportantNotification notification = ImportantNotification(
+          userId: user.id,
+          date: DateTime.now(),
+          info: "Su subcripción se acaba de cambiar al plan gratuito.");
+      user.notifications.add(notification);
+    }
+
+    // Set all the event points to invisible
+    eventPointsService.setUsersEventPointsToInvisible(user);
 
     await usersService.addItem(user);
+
+    return user;
   }
 
-  Future<void> changePlanToPremium(User user) async {
+  Future<User> changePlanToPremium(User user) async {
     user.subscription.type = SubscriptionType.premium;
     user.subscription.numEventsCreatedThisMonth = 0;
     user.subscription.validUntil = DateTime.now().add(const Duration(days: 30));
+    user.subscription.lastReset = DateTime.now();
+
+    // Add a notification to the user
+    ImportantNotification notification = ImportantNotification(
+        userId: user.id,
+        date: DateTime.now(),
+        info: "Su subcripción se acaba de cambiar al plan premium.");
+    user.notifications.add(notification);
+
+    // Set all the event points to invisible
+    eventPointsService.setUsersEventPointsToInvisible(user);
 
     await usersService.addItem(user);
+
+    return user;
   }
 
-  Future<void> changePlanToCompany(User user) async {
+  Future<User> changePlanToCompany(User user) async {
     user.subscription.type = SubscriptionType.company;
     user.subscription.numEventsCreatedThisMonth = 0;
     user.subscription.validUntil = DateTime.now().add(const Duration(days: 30));
+    user.subscription.lastReset = DateTime.now();
+
+    // Add a notification to the user
+    ImportantNotification notification = ImportantNotification(
+        userId: user.id,
+        date: DateTime.now(),
+        info: "Su subcripción se acaba de cambiar al plan empresa.");
+    user.notifications.add(notification);
+
+    // Set all the event points to visible
+    eventPointsService.setUsersEventPointsToVisible(user);
 
     await usersService.addItem(user);
+
+    return user;
+  }
+
+  Future<User> checkSubscriptionValidity(User user) async {
+    if (user.subscription.isExpired) {
+      User newUser = await changePlanToFree(user, expired: true);
+      return newUser;
+    } else if (user.subscription.needsReset) {
+      User newUser = await resetSubscription(user);
+      return newUser;
+    }
+    return user;
   }
 }

--- a/lib/services/users_service.dart
+++ b/lib/services/users_service.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 //import 'dart:html';
 
-import 'package:findmyfun/services/auth_service.dart';
+import 'package:findmyfun/services/services.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import '../models/user.dart';
@@ -29,7 +29,9 @@ class UsersService extends ChangeNotifier {
       if (resp.statusCode == 200) {
         Map<String, dynamic> data = jsonDecode(resp.body);
         user = User.fromJson(data);
-        return user;
+        User newUser =
+            await SubscriptionService().checkSubscriptionValidity(user);
+        return newUser;
       } else {
         throw Exception(
             'Errors ocurred while trying to get the user with Uid $userUid');
@@ -48,7 +50,9 @@ class UsersService extends ChangeNotifier {
       if (resp.statusCode == 200) {
         Map<String, dynamic> data = jsonDecode(resp.body);
         user = User.fromJson(data);
-        currentUser = user;
+        User newUser =
+            await SubscriptionService().checkSubscriptionValidity(user);
+        currentUser = newUser;
       } else {
         throw Exception(
             'Errors ocurred while trying to get the current user with Uid $activeUserId');

--- a/lib/views/event/event_details.dart
+++ b/lib/views/event/event_details.dart
@@ -68,6 +68,8 @@ class _FormsColumn extends StatelessWidget {
     final eventService = Provider.of<EventsService>(context, listen: false);
     final userService = Provider.of<UsersService>(context, listen: false);
     final creator = userService.getUserWithUid(selectedEvent.creator);
+    String activeUserId = AuthService().currentUser?.uid ?? "";
+    final activeUserFuture = userService.getUserWithUid(activeUserId);
 
     //List<String> asistentesList = [];
     Future<List<String>> asistentes = Future.delayed(Duration.zero, () async {
@@ -78,7 +80,6 @@ class _FormsColumn extends StatelessWidget {
     });
 
     //print(asistentes);
-    String activeUserId = AuthService().currentUser?.uid ?? "";
     late User creatorUser;
     bool creatorSameAsCurrentUser = activeUserId == selectedEvent.users.first;
 
@@ -193,19 +194,33 @@ class _FormsColumn extends StatelessWidget {
               const SizedBox(
                 height: 20,
               ),
-              if (!selectedEvent.users.contains(activeUserId) &&
-                  !selectedEvent.isFull)
-                SubmitButton(
-                  text: 'Unirse',
-                  onTap: () => {
-                    eventService.addUserToEvent(context, selectedEvent),
-                    Navigator.pushReplacement(
-                        context,
-                        MaterialPageRoute(
-                            builder: (context) => const EventDetailsView(),
-                            settings: RouteSettings(arguments: selectedEvent)))
-                  },
-                ),
+              FutureBuilder<User>(
+                future: activeUserFuture,
+                builder: (context, snapshot) {
+                  if (snapshot.hasData &&
+                      !selectedEvent.users.contains(activeUserId) &&
+                      !selectedEvent.isFull &&
+                      snapshot.data!.subscription.type !=
+                          SubscriptionType.company) {
+                    return SubmitButton(
+                      text: 'Unirse',
+                      onTap: () => {
+                        eventService.addUserToEvent(context, selectedEvent),
+                        Navigator.pushReplacement(
+                            context,
+                            MaterialPageRoute(
+                                builder: (context) => const EventDetailsView(),
+                                settings:
+                                    RouteSettings(arguments: selectedEvent)))
+                      },
+                    );
+                  } else if (snapshot.hasError) {
+                    return Text('${snapshot.error}');
+                  } else {
+                    return const SizedBox();
+                  }
+                },
+              ),
               if (selectedEvent.users.contains(activeUserId))
                 ElevatedButton(
                   child: const AutoSizeText(

--- a/lib/views/register/register_view_form.dart
+++ b/lib/views/register/register_view_form.dart
@@ -168,11 +168,13 @@ class _RegisterFormContainerState extends State<_RegisterFormContainer> {
                       models.ImportantNotification(
                           date: DateTime.now(),
                           userId: credential.user!.uid,
-                          info: 'Bienvenido a FindMyFun, ¡esperamos que pueda conocer gente para hacer planes que le interese y disfrutar de todo lo que nuestra aplicación le ofrece!'),
+                          info:
+                              'Bienvenido a FindMyFun, ¡esperamos que pueda conocer gente para hacer planes que le interese y disfrutar de todo lo que nuestra aplicación le ofrece!'),
                     ],
                     subscription: models.Subscription(
                         type: models.SubscriptionType.free,
-                        numEventsCreatedThisMonth: 0));
+                        numEventsCreatedThisMonth: 0,
+                        lastReset: DateTime.now()));
                 final resp =
                     await userService.addItem(userService.currentUser!);
                 if (resp) {

--- a/test/unit_tests.dart
+++ b/test/unit_tests.dart
@@ -73,8 +73,10 @@ void main() {
     preferencesTest.add(preferenceTest);
     List<String> usersTest = [];
     usersTest.add("idtest");
-    Subscription subscriptionTest =
-        Subscription(numEventsCreatedThisMonth: 0, type: SubscriptionType.free);
+    Subscription subscriptionTest = Subscription(
+        numEventsCreatedThisMonth: 0,
+        type: SubscriptionType.free,
+        lastReset: DateTime.now());
     User user = User(
         name: nameTest,
         surname: surnameTest,
@@ -114,7 +116,9 @@ void main() {
     List<String> usersTest = [];
     usersTest.add("idtest");
     Subscription subscriptionTest = Subscription(
-        numEventsCreatedThisMonth: 0, type: SubscriptionType.company);
+        numEventsCreatedThisMonth: 0,
+        type: SubscriptionType.company,
+        lastReset: DateTime.now());
     User user = User(
         name: nameTest,
         surname: surnameTest,
@@ -156,7 +160,9 @@ void main() {
     List<String> usersTest = [];
     usersTest.add("idtest");
     Subscription subscriptionTest = Subscription(
-        numEventsCreatedThisMonth: 0, type: SubscriptionType.premium);
+        numEventsCreatedThisMonth: 0,
+        type: SubscriptionType.premium,
+        lastReset: DateTime.now());
     User user = User(
         name: nameTest,
         surname: surnameTest,
@@ -196,8 +202,10 @@ void main() {
     preferencesTest.add(preferenceTest);
     List<String> usersTest = [];
     usersTest.add("idtest");
-    Subscription subscriptionTest =
-        Subscription(numEventsCreatedThisMonth: 0, type: SubscriptionType.free);
+    Subscription subscriptionTest = Subscription(
+        numEventsCreatedThisMonth: 0,
+        type: SubscriptionType.free,
+        lastReset: DateTime.now());
     List<ImportantNotification> notificationsTest = [];
     ImportantNotification firstNotification = ImportantNotification(
         userId: "usertestnotification",
@@ -248,6 +256,8 @@ void main() {
         "https://www.freecodecamp.org/espanol/news/content/images/2022/02/5f9c9a4c740569d1a4ca24c2.jpg";
     double latitudeTest = 0;
     double longitudeTest = 0;
+    bool visibleTest = true;
+    String creatorIdTest = "idtest";
     EventPoint eventPoint = EventPoint(
         address: addressTest,
         city: cityTest,
@@ -257,7 +267,9 @@ void main() {
         name: nameTest,
         latitude: latitudeTest,
         longitude: longitudeTest,
-        id: idTest);
+        id: idTest,
+        visible: visibleTest,
+        creatorId: creatorIdTest);
     assert(eventPoint.address == addressTest);
     assert(eventPoint.city == cityTest);
     assert(eventPoint.country == countryTest);
@@ -267,5 +279,7 @@ void main() {
     assert(eventPoint.latitude == latitudeTest);
     assert(eventPoint.longitude == longitudeTest);
     assert(eventPoint.id == idTest);
+    assert(eventPoint.visible == visibleTest);
+    assert(eventPoint.creatorId == creatorIdTest);
   });
 }


### PR DESCRIPTION
- El botón de unirse a un evento debe de estar oculto para los usuarios de tipo de empresa.

Los siguientes cambios surten efecto cuando se carga el usuario desde la base de datos. Puedes probar iniciando sesión o yendo al perfil:
- Si un usuario tiene caducada su subscripción, se le cambia la subscripción a una gratuita y se le añade una notificación.
  Puedes probarlo cambiando la fecha validUntil manualmente a una fecha pasada y viendo si funciona.
- Cuando se cambia la subscripción de un usuario de company a free o premium, los EventPoints cuyos creatorId sean iguales al id del usuario serán ocultados (poniendo el valor visible a false).
  Nota: Los EventPoints que no tengan el atributo creatorId en la base de datos no se cargarán en la app.

- Si ha pasado más de un mes desde el último reseteo de la subscripción de un usuario, se le resetea dicha subscripción poniéndole el conteo de eventos creados a cero y estableciendo la fecha lastReset la fecha actual.
  Puedes probarlo cambiando la fecha lastReset manualmente a una fecha pasada (al menos un mes) y viendo si funciona.