### PR TITLE
Arreglos para hacer la vista de preferencias responsive

### DIFF
--- a/lib/views/home/preferences/preferences_view.dart
+++ b/lib/views/home/preferences/preferences_view.dart
@@ -13,6 +13,7 @@ class PreferencesView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
     return SafeArea(
       child: Scaffold(
           appBar: AppBar(
@@ -30,11 +31,11 @@ class PreferencesView extends StatelessWidget {
                 maxLines: 1, textAlign: TextAlign.center, style: Styles.appBar),
           ),
           // backgroundColor: ProjectColors.primary,
-          body: Column(children: const [
+          body: Column(children:  [
             SizedBox(
-              height: 20,
+              height: size.height*0.02,
             ),
-            PreferencesContainer(
+            const PreferencesContainer(
               child: PreferencesColumn(),
             )
           ])),
@@ -66,6 +67,7 @@ class _PreferencesColumnState extends State<PreferencesColumn> {
 
   @override
   Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
     final preferencesService = Provider.of<PreferencesService>(context);
     final preferences = preferencesService.preferences;
     final preferencesNames = preferences.map((e) => e.name).toList();
@@ -79,14 +81,14 @@ class _PreferencesColumnState extends State<PreferencesColumn> {
           selectedPreferences = snapshot.data;
 
           return Column(children: [
-            const SizedBox(
-              height: 10,
+            SizedBox(
+              height: size.height*0.02,
             ),
             Expanded(
                 child: ListView(
               children: [
                 SizedBox(
-                  height: 480,
+                  height: size.height*0.6,
                   child: CustomScrollView(
                     slivers: <Widget>[
                       SliverList(
@@ -99,8 +101,8 @@ class _PreferencesColumnState extends State<PreferencesColumn> {
                               child: Padding(
                                 padding: const EdgeInsets.only(bottom: 10.0),
                                 child: SizedBox(
-                                  height: 80,
-                                  width: 325,
+                                  height: size.height*0.1,
+                                  width: size.height*0.42,
                                   child: ElevatedButton(
                                       style: ButtonStyle(
                                           shape: MaterialStateProperty.all<
@@ -124,18 +126,10 @@ class _PreferencesColumnState extends State<PreferencesColumn> {
                                             //Si una preferencia seleccionada se presiona, es eliminada de la lista
                                             selectedPreferences
                                                 .remove(preferences[index]);
-                                            ScaffoldMessenger.of(context)
-                                                .showSnackBar(SnackBar(
-                                                    content: Text(
-                                                        'Se ha deseleccionado la preferencia ${preferences[index].name}')));
                                           } else {
                                             //Si una preferencia sin seleccionar se presiona, es añadida a la lista
                                             selectedPreferences
                                                 .add(preferences[index]);
-                                            ScaffoldMessenger.of(context)
-                                                .showSnackBar(SnackBar(
-                                                    content: Text(
-                                                        'Se ha seleccionado la preferencia ${preferences[index].name}')));
                                           }
                                         });
                                       },
@@ -153,6 +147,9 @@ class _PreferencesColumnState extends State<PreferencesColumn> {
                     ],
                   ),
                 ),
+                SizedBox(
+                  height: size.height*0.01,
+                ),
                 FloatingActionButton(
                   onPressed: () {
                     // When merge, change first option by current user id
@@ -168,8 +165,8 @@ class _PreferencesColumnState extends State<PreferencesColumn> {
                   },
                   child: const Icon(Icons.save),
                 ),
-                const SizedBox(
-                  height: 10,
+                SizedBox(
+                  height: size.height*0.01,
                 ),
                 const AutoSizeText(
                     'Recuerda guardar para que se actualize tu perfil',

--- a/lib/views/register/payment_view.dart
+++ b/lib/views/register/payment_view.dart
@@ -18,20 +18,6 @@ class _PaymentViewUserState extends State<PaymentViewUser> {
           title: Text(
             'Pago por PayPal',
           ),
-          actions: [
-            Container(
-              margin: EdgeInsets.only(right: 15),
-              child: IconButton(
-                  onPressed: () {
-                    Navigator.pushReplacementNamed(context, 'main');
-                  },
-                  icon: Icon(
-                    Icons.home,
-                    size: 44,
-                    color: Colors.white,
-                  )),
-            )
-          ],
         ),
         body: Column(
           children: [

--- a/lib/views/register/payment_view2.dart
+++ b/lib/views/register/payment_view2.dart
@@ -15,23 +15,9 @@ class _PaymentViewBusinessState extends State<PaymentViewBusiness> {
     return Scaffold(
         appBar: AppBar(
           backgroundColor: ProjectColors.tertiary,
-          title: Text(
+          title: const Text(
             'Pago por PayPal',
           ),
-          actions: [
-            Container(
-              margin: EdgeInsets.only(right: 15),
-              child: IconButton(
-                  onPressed: () {
-                    Navigator.pushReplacementNamed(context, 'main');
-                  },
-                  icon: Icon(
-                    Icons.home,
-                    size: 44,
-                    color: Colors.white,
-                  )),
-            )
-          ],
         ),
         body: Center(
           child: TextButton(

--- a/lib/widgets/preferences_container.dart
+++ b/lib/widgets/preferences_container.dart
@@ -9,9 +9,10 @@ class PreferencesContainer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
     return Container(
       width: double.infinity,
-      height: 600,
+      height: size.height*0.8,
       margin: const EdgeInsets.symmetric(horizontal: 15),
       decoration: const BoxDecoration(color: Color(0xff828a92)),
       child: child,


### PR DESCRIPTION
Ahora todos los tamaños se dan por porcentajes de pantalla para que sea responsive. Además se ha eliminado el mensaje que salia al seleccionar/deseleccionar una preferencia