### PR TITLE
fix: Arreglado formato de fecha y estilo del hintText de edición de evento propio

### DIFF
--- a/lib/views/event/event_details.dart
+++ b/lib/views/event/event_details.dart
@@ -114,9 +114,11 @@ class _FormsColumnState extends State<_FormsColumn> {
     final creator = userService.getUserWithUid(selectedEvent.creator);
     String activeUserId = AuthService().currentUser?.uid ?? "";
     final activeUserFuture = userService.getCurrentUserWithUid();
+    final formattedDate =
+        DateFormat('yyyy-MM-dd HH:mm').format(selectedEvent.startDate);
 
     _description.text = selectedEvent.description;
-    _startDateTime.text = selectedEvent.startDate.toIso8601String();
+    _startDateTime.text = formattedDate;
     _locationController.text = selectedEvent.address;
     _cityController.text = selectedEvent.city;
 
@@ -166,6 +168,10 @@ class _FormsColumnState extends State<_FormsColumn> {
                 ),
                 CustomTextDetail(
                   hintText: selectedEvent.address,
+                  hintStyle: const TextStyle(
+                    color: Colors.grey,
+                    fontSize: 16.0,
+                  ),
                   enabled: widget.canEdit,
                   controller: _locationController,
                   validator: (val) => Validators.validateNotEmpty(val),
@@ -186,6 +192,10 @@ class _FormsColumnState extends State<_FormsColumn> {
                 ),
                 CustomTextDetail(
                   hintText: selectedEvent.city,
+                  hintStyle: const TextStyle(
+                    color: Colors.grey,
+                    fontSize: 16.0,
+                  ),
                   enabled: widget.canEdit,
                   controller: _cityController,
                   validator: (val) => Validators.validateNotEmpty(val),
@@ -207,6 +217,10 @@ class _FormsColumnState extends State<_FormsColumn> {
                 CustomTextDetail(
                   hintText: DateFormat('yyyy-MM-dd HH:mm')
                       .format(selectedEvent.startDate),
+                  hintStyle: const TextStyle(
+                    color: Colors.grey,
+                    fontSize: 16.0,
+                  ),
                   enabled: widget.canEdit,
                   maxLines: 3,
                   controller: _startDateTime,
@@ -230,6 +244,10 @@ class _FormsColumnState extends State<_FormsColumn> {
                 ),
                 CustomTextDetail(
                   hintText: selectedEvent.description,
+                  hintStyle: const TextStyle(
+                    color: Colors.grey,
+                    fontSize: 16.0,
+                  ),
                   enabled: widget.canEdit,
                   maxLines: 5,
                   type: TextInputType.multiline,
@@ -382,6 +400,10 @@ class _FormsColumnState extends State<_FormsColumn> {
               ),
               CustomTextDetail(
                 hintText: selectedEvent.address,
+                hintStyle: const TextStyle(
+                  color: Colors.grey,
+                  fontSize: 16.0,
+                ),
                 enabled: false,
               ),
               const SizedBox(
@@ -396,6 +418,10 @@ class _FormsColumnState extends State<_FormsColumn> {
               ),
               CustomTextDetail(
                 hintText: selectedEvent.city,
+                hintStyle: const TextStyle(
+                  color: Colors.grey,
+                  fontSize: 16.0,
+                ),
                 enabled: false,
               ),
               const SizedBox(
@@ -410,6 +436,10 @@ class _FormsColumnState extends State<_FormsColumn> {
               ),
               CustomTextDetail(
                 hintText: selectedEvent.startDate.toString(),
+                hintStyle: const TextStyle(
+                  color: Colors.grey,
+                  fontSize: 16.0,
+                ),
                 enabled: false,
               ),
               const SizedBox(
@@ -424,6 +454,10 @@ class _FormsColumnState extends State<_FormsColumn> {
               ),
               CustomTextDetail(
                 hintText: selectedEvent.description,
+                hintStyle: const TextStyle(
+                  color: Colors.grey,
+                  fontSize: 16.0,
+                ),
                 enabled: false,
                 maxLines: 4,
                 type: TextInputType.multiline,

--- a/lib/widgets/custom_text_details.dart
+++ b/lib/widgets/custom_text_details.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 class CustomTextDetail extends StatelessWidget {
   final String hintText;
+  final TextStyle hintStyle;
   final bool obscure;
   final EdgeInsets? padding;
   final int? maxLines;
@@ -14,6 +15,7 @@ class CustomTextDetail extends StatelessWidget {
   const CustomTextDetail({
     super.key,
     required this.hintText,
+    this.hintStyle = const TextStyle(color: Colors.black87, fontSize: 26),
     this.obscure = false,
     this.padding = const EdgeInsets.all(10),
     this.maxLines = 1,
@@ -46,7 +48,7 @@ class CustomTextDetail extends StatelessWidget {
         decoration: InputDecoration(
           enabledBorder: InputBorder.none,
           hintText: hintText,
-          hintStyle: const TextStyle(color: Colors.black87, fontSize: 26),
+          hintStyle: hintStyle,
           border: InputBorder.none,
         ),
       ),


### PR DESCRIPTION
El error estaba en la linea que cambia el valor de _startDateTime.text, que no se le pasaba la fecha parseada.

Se ha modificado también el widget CustomTextDetail para que permita un parámetro opcional "hintStyle" que tiene por defecto el valor que ya tenia el campo hintStyle dentro del TextFormField que hay en CustomTextDetail. Con él se puede modificar si se desea el estilo de los placeholders de los campos de los formularios, que en la edición de evento tenía una apariencia un poco rara, ahora el estilo de esos placeholders es el mismo que el del texto que se escribe en ellos pero con un tono grisáceo, y no una letra enorme y negra.