### PR TITLE
fix: Muestra en el mapa solo los eventos recomendados

### DIFF
--- a/lib/services/map_service.dart
+++ b/lib/services/map_service.dart
@@ -14,22 +14,17 @@ class MapService extends ChangeNotifier {
     List<Point> markers = [];
 
     String currentUser = AuthService().currentUser?.uid ?? "";
-    List<Event> events = await eventsService.getEvents();
+    List<Event> events = await eventsService.findEvents();
     List<EventPoint> eventPoints = await eventPointsService.getEventPoints();
 
     for (var event in events) {
-      if (event.hasFinished || !event.isVisible) continue;
-      if (event.isFull && !event.users.contains(currentUser)) continue;
       markers.add(Point(
           event: event,
           marker: Marker(
             markerId: MarkerId(event.id),
             position: LatLng(event.latitude, event.longitude),
-            icon: event.users.contains(currentUser)
-                ? BitmapDescriptor.defaultMarkerWithHue(
-                    BitmapDescriptor.hueMagenta)
-                : BitmapDescriptor.defaultMarkerWithHue(
-                    BitmapDescriptor.hueRed),
+            icon:
+                BitmapDescriptor.defaultMarkerWithHue(BitmapDescriptor.hueRed),
           )));
     }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -277,6 +277,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  fluttertoast:
+    dependency: "direct main"
+    description:
+      name: fluttertoast
+      sha256: "2f9c4d3f4836421f7067a28f8939814597b27614e021da9d63e5d3fb6e212d25"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.2.1"
   geocoding:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   flutter_paypal: ^0.0.8
   google_mobile_ads: ^2.4.0
   auto_size_text: ^3.0.0
+  fluttertoast: ^8.2.1
 
 dev_dependencies:
   flutter_lints: ^2.0.0


### PR DESCRIPTION
Comprobar lo siguiente:
- Solo se muestran en el mapa los eventos recomendados (los mismos que salen en la sección de eventos recomendados).
- El botón de centrar el mapa debe de seguir funcionando. Probar también con bluestacks.